### PR TITLE
Fix release task so that deleted distributables are included in the git commit

### DIFF
--- a/gulp/release.js
+++ b/gulp/release.js
@@ -39,13 +39,13 @@ context.gulp.task('av:noop', function() {
 });
 
 context.gulp.task('av:release:add', function() {
-  return context.gulp.src(path.join(process.cwd(), './dist/*'))
-    .pipe(git.add({args: '-f'}));
+  return context.gulp.src(path.join(process.cwd(), './dist/'))
+    .pipe(git.add({args: '-fA'}));
 });
 
 context.gulp.task('av:release:tag', function() {
 
-  return context.gulp.src(['./package.json', './bower.json', './dist/*', 'README.md'])
+  return context.gulp.src(['./package.json', './bower.json', './dist/', 'README.md'])
     .pipe(git.commit('bump package version v' + getPkg())) // commit the changed version number
     .pipe(filter('package.json'))
     .pipe(tagVersion());


### PR DESCRIPTION
Currently, old files in the dist/ folder are not included in the git commit when releasing a new version of an app. In other words, the old files are removed from the file system, but not removed in git. Currently, after running a release, git will show files as missing from the dist/ folder, and the developer is forced to remove them manually. These changes will correct the issue.