### PR TITLE
[Close #15] Feature/json support

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "istanbul-instrumenter-loader": "0.1.3",
     "jasmine-core": "^2.3.4",
     "joi": "^6.6.1",
+    "json-loader": "^0.5.3",
     "karma": "^0.13.9",
     "karma-chrome-launcher": "^0.2.0",
     "karma-coverage": "^0.5.2",

--- a/webpack/webpack-config.js
+++ b/webpack/webpack-config.js
@@ -109,7 +109,8 @@ var config = {
         loader: 'file?name=fonts/[name].[ext]'
       },
       {test: /\.(\.jpe?g|png|gif)$/, loader: 'file?name=images/[name].[ext]'},
-      {test: /\.html$/, loader: 'html'}
+      {test: /\.html$/, loader: 'html'},
+      {test: /\.json$/, loader: 'json-loader'}
 
     ]
   },


### PR DESCRIPTION
node.js has the ability to require a json file natively without any plugin.

For our project, currently we have all the convenience of node.js-styled require/module.export through webpack, but lack native json support.

It would be nice to add such a support through https://github.com/webpack/json-loader, so that .json file can be used/required directly without module.exports as a .js file.