### PR TITLE
Config warning message always shows

### DIFF
--- a/context/index.js
+++ b/context/index.js
@@ -4,7 +4,9 @@ var utils = require('../utils');
 var Context = function() {
 
   this.settings = require('../settings');
-  this.meta = {};
+  this.meta = {
+    developerConfig: true
+  };
 
   var environment = utils.env.load(this);
   _.merge(this.settings, environment);


### PR DESCRIPTION
config.meta.developerConfig is set to false if file doesn't exist,
warning message uses !config.meta.devloperConfig which will return true if its undefined, so warning message always is triggered.