### PR TITLE
Remove allchunks flag from the extractTextPlugin

### DIFF
--- a/webpack/index.js
+++ b/webpack/index.js
@@ -160,9 +160,7 @@ const config = {
     new CaseSensitivePathsPlugin(),
 
     // Use bundle name for extracting bundle css
-    new ExtractTextPlugin(`css/${settings.css()}`, {
-      allChunks: true
-    }),
+    new ExtractTextPlugin(`css/${settings.css()}`),
 
     new HtmlWebpackPlugin({
       template: './index.html',


### PR DESCRIPTION
Remove the AllChunks flag. This was causing an issue with memory allocation during the hashing process.