### PR TITLE
Cleanup: remove autoprefixer-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   },
   "dependencies": {
     "autoprefixer": "6.4.0",
-    "autoprefixer-loader": "^3.0.0",
     "availity-ekko": "1.3.0",
     "babel-core": "6.13.0",
     "babel-eslint": "6.1.2",


### PR DESCRIPTION
This package is deprecated and doesn't appear to be used by workflow anymore since it uses postcss-loader.