### PR TITLE
Added optional EventEmitter to context.  Raised event when webpack bundle is complete.

### DIFF
--- a/context/index.js
+++ b/context/index.js
@@ -17,7 +17,7 @@ proto.set = function(context) {
 
   var self = this;
 
-  _.forEach(['gulp', 'webpack', 'karma'], function(value) {
+  _.forEach(['gulp', 'webpack', 'karma', 'eventEmitter'], function(value) {
     self[value] = context[value];
   });
 
@@ -26,6 +26,13 @@ proto.set = function(context) {
 proto.getConfig = function() {
   var environment = process.env.NODE_ENV || 'development';
   return this.settings[environment];
+};
+
+proto.emit = function () {
+  var self = this;
+  if (self.eventEmitter) {
+    self.eventEmitter.apply(self.eventEmitter, arguments);
+  }
 };
 
 

--- a/context/index.js
+++ b/context/index.js
@@ -1,3 +1,4 @@
+var EventEmitter = require('events');
 var _ = require('lodash');
 var utils = require('../utils');
 
@@ -31,7 +32,7 @@ proto.getConfig = function() {
 proto.emit = function () {
   var self = this;
   if (self.eventEmitter) {
-    self.eventEmitter.apply(self.eventEmitter, arguments);
+    EventEmitter.prototype.emit.apply(self.eventEmitter, arguments);
   }
 };
 

--- a/hapi/plugin-webpack.js
+++ b/hapi/plugin-webpack.js
@@ -4,6 +4,7 @@ var _ = require('lodash');
 
 var logger = require('../logger');
 var check = require('../dev/check');
+var context = require('../context');
 
 function bundle(server, options, next) {
 
@@ -14,6 +15,7 @@ function bundle(server, options, next) {
   var done = _.after(bundleCounts, function() {
     logger.info(statistics[0]);
     logger.ok('Finished bundling');
+    context.emit('av:bundle-complete');
     next();
   });
 


### PR DESCRIPTION
I'm trying to incorporate browser-sync into my process, and this seemed like a nice unobtrusive way to give users the ability to know when webpack has finished building without coupling availity-workflow to browser-sync in particular.

If there is already a better way to get notified of builds completing, feel free to reject this PR and let me know how I can accomplish that.
