### PR TITLE
Remove pinned version

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint": "^1.3.1",
     "exists-sync": "0.0.3",
     "exports-loader": "^0.6.2",
-    "expose-loader": "0.7.1",
+    "expose-loader": "^0.7.3",
     "extract-text-webpack-plugin": "1.0.1",
     "figures": "1.7.0",
     "file-loader": "^0.8.1",


### PR DESCRIPTION
Expose-loader 0.7.3 seems to fix the issue, so removing the pinned version