### PR TITLE
Stringify config globals to allow nested objects

### DIFF
--- a/packages/availity-workflow-logger/README.md
+++ b/packages/availity-workflow-logger/README.md
@@ -44,7 +44,7 @@ Prints an error message in `red` with a cross symbol and error label
 ✖ [ ERROR] Failed linting
 ```
 
-### `successs`
+### `success`
 Prints a success message in `green` with a checkbox symbol.
 
 ```bash

--- a/packages/availity-workflow-settings/index.js
+++ b/packages/availity-workflow-settings/index.js
@@ -8,6 +8,18 @@ const fs = require('fs');
 const yaml = require('js-yaml');
 const get = require('lodash.get');
 const argv = require('yargs').argv;
+const _ = require('lodash');
+
+function stringify(obj) {
+  _.each(obj, (value, key) => {
+    if (_.isString(value)) {
+      obj[key] = JSON.stringify(value);
+    } else if (_.isObject(value) && !_.isFunction(value)) {
+      stringify(value);
+    }
+  });
+  return obj;
+}
 
 const settings = {
 
@@ -92,7 +104,7 @@ const settings = {
 
   globals() {
 
-    const configGlobals = get(this.configuration, 'globals', {});
+    const configGlobals = stringify(get(this.configuration, 'globals', {}));
 
     const env = this.environment();
 

--- a/packages/availity-workflow/README.md
+++ b/packages/availity-workflow/README.md
@@ -40,6 +40,9 @@ Lint project files using EsLint.
 ##### `--include`
 Include additional glob patterns for linting.
 
+##### `--ignore-git-untracked`
+Ignore files that are not indexed by git.
+
 ### `build`
 - Cleans up `/dist` folder
 - Bundles project assets into the `/dist` folder

--- a/packages/availity-workflow/index.js
+++ b/packages/availity-workflow/index.js
@@ -34,8 +34,12 @@ yargs
       .option('fail', {
         alias: 'f',
         describe: 'Force linter to fail and exit'
+      })
+      .option('ignore-git-untracked', {
+        alias: 'u',
+        describe: 'Ignore files that are not indexed by git'
       });
-  }, () => { lint().catch(() => { /* noop */}) })
+  }, (yyargs) => { lint(yyargs).catch(() => { /* noop */}) })
 
   .command('test', `${chalk.dim(test.description)}`, yyargs => {
     return yyargs

--- a/packages/availity-workflow/scripts/lint.js
+++ b/packages/availity-workflow/scripts/lint.js
@@ -8,7 +8,7 @@ const settings = require('availity-workflow-settings');
 const path = require('path');
 const { spawnSync } = require('child_process');
 
-function lint() {
+function lint(argv = {}) {
 
   let engine;
 
@@ -36,15 +36,17 @@ function lint() {
 
     // files tracked by git
     let gitTrackedFiles;
-    const gitRootCmd = spawnSync('git', ['rev-parse', '--show-toplevel']);
-    if (gitRootCmd.status) {
-      // non-zero exit code; assume git repository absent
-      gitTrackedFiles = null;
-    } else {
-      const gitLsFiles = spawnSync('git', ['ls-files']);
-      gitTrackedFiles = gitLsFiles.stdout.toString().trim().split('\n');
-      const gitRoot = gitRootCmd.stdout.toString().trim();
-      gitTrackedFiles = gitTrackedFiles.map((f) => path.join(gitRoot, f));
+    if (argv.ignoreGitUntracked) {
+      const gitRootCmd = spawnSync('git', ['rev-parse', '--show-toplevel']);
+      if (gitRootCmd.status) {
+        // non-zero exit code; assume git repository absent
+        gitTrackedFiles = null;
+      } else {
+        const gitLsFiles = spawnSync('git', ['ls-files']);
+        gitTrackedFiles = gitLsFiles.stdout.toString().trim().split('\n');
+        const gitRoot = gitRootCmd.stdout.toString().trim();
+        gitTrackedFiles = gitTrackedFiles.map((f) => path.join(gitRoot, f));
+      }
     }
 
     // Uses globby which defaults to process.cwd() and path.resolve(options.cwd, "/")

--- a/packages/availity-workflow/scripts/lint.js
+++ b/packages/availity-workflow/scripts/lint.js
@@ -5,6 +5,8 @@ const ora = require('ora');
 const chalk = require('chalk');
 const Logger = require('availity-workflow-logger');
 const settings = require('availity-workflow-settings');
+const path = require('path');
+const { spawnSync } = require('child_process');
 
 function lint() {
 
@@ -32,14 +34,29 @@ function lint() {
     spinner.color = 'yellow';
     spinner.start();
 
-    const files = settings.js();
+    // files tracked by git
+    let gitTrackedFiles;
+    const gitRootCmd = spawnSync('git', ['rev-parse', '--show-toplevel']);
+    if (gitRootCmd.status) {
+      // non-zero exit code; assume git repository absent
+      gitTrackedFiles = null;
+    } else {
+      const gitLsFiles = spawnSync('git', ['ls-files']);
+      gitTrackedFiles = gitLsFiles.stdout.toString().trim().split('\n');
+      const gitRoot = gitRootCmd.stdout.toString().trim();
+      gitTrackedFiles = gitTrackedFiles.map((f) => path.join(gitRoot, f));
+    }
 
     // Uses globby which defaults to process.cwd() and path.resolve(options.cwd, "/")
-    globby(files).then(paths => {
+    globby(settings.js()).then(paths => {
 
       spinner.stop();
+      const filesToLint = gitTrackedFiles ?
+        // git repository present
+        paths.filter((f) => ~gitTrackedFiles.indexOf(f)) :
+        paths;
 
-      const report = engine.executeOnFiles(paths);
+      const report = engine.executeOnFiles(filesToLint);
 
       if (report.errorCount || report.warningCount) {
 


### PR DESCRIPTION
Webpack Globals can better be taken advantage of when strings are represented by, wait for it, _strings_. One sample use case is storing environment-specific configuration for API routes to be determined at build time.