### PR TITLE
Add leading forward slash to opts

### DIFF
--- a/packages/availity-react-kit/project/app/Request/api/requestApi.js
+++ b/packages/availity-react-kit/project/app/Request/api/requestApi.js
@@ -1,10 +1,10 @@
 import { defaults, get } from 'axios';
 import map from 'lodash.map';
 
-const ORGANIZATIONS_OPTS = 'api/sdk/platform/v1/organizations';
-const PROVIDERS_OPTS = 'api/internal/v1/providers';
-const USER_OPTS = 'api/sdk/platform/v1/users/me';
-const AUTHORIZATIONS_OPTS = 'api/v1/proxy/healthplan/v1/authorizations';
+const ORGANIZATIONS_OPTS = '/api/sdk/platform/v1/organizations';
+const PROVIDERS_OPTS = '/api/internal/v1/providers';
+const USER_OPTS = '/api/sdk/platform/v1/users/me';
+const AUTHORIZATIONS_OPTS = '/api/v1/proxy/healthplan/v1/authorizations';
 
 export const getUser = () => get(USER_OPTS);
 


### PR DESCRIPTION
Bugfix. API requests in example were relative rather than absolute to origin