### PR TITLE
fix(react kit): fix incorrect dep version

### DIFF
--- a/packages/availity-react-kit/package.json
+++ b/packages/availity-react-kit/package.json
@@ -51,7 +51,7 @@
     "react-dom": "^15.6.1",
     "react-router-dom": "4.1.2",
     "react-select": "^1.0.0-rc.5",
-    "react-transition-group": "^2.2.0",
+    "react-transition-group": "^1.2.0",
     "reactstrap": "^4.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
reactstrap needs a peerDep of react-transition-group@^1.1.2 (this has been removed in reactstrap v5 but we cannot upgrade to that just yet)