### PR TITLE
fix(fontRule): filename no longer needs hyphen

### DIFF
--- a/packages/availity-workflow-settings/webpack/rule-fonts.js
+++ b/packages/availity-workflow-settings/webpack/rule-fonts.js
@@ -4,6 +4,6 @@ module.exports = {
   //  '../fonts/availity-font.eot?18704236'
   //  '../fonts/availity-font.eot'
   //
-  test: /-font\.(otf|ttf|woff2?|eot|svg)(\?.+)?$/,
+  test: /font\.(otf|ttf|woff2?|eot|svg)(\?.+)?$/,
   use: ['file-loader?name=fonts/[name].[ext]']
 };


### PR DESCRIPTION
Imported fonts no longer need the hyphen, they just need to end with `font` before the dot-extension.
This allows for webfont to be caught.

Closes #137