### PR TITLE
feat(availity-workflow): add option to allow user to modify the webpack config

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,24 @@ headers: {
   RemoteUser: 'janedoe'
 }
 ```
+
+#### `modifyWebpackConfig`
+A function which, when provided, can be used to enhance/override or replace the webpack configuration used. The function will be invoked with the current webpack configuration object and a reference to the workflow settings.
+
+**Ex:**
+```js
+modifyWebpackConfig: (webpackConfig, settings) => {
+  // Add Subresource Integrity (SRI) security feature
+  webpackConfig.output = { crossOriginLoading: 'anonymous' };
+  // Note: SriPlugin would be imported in your workflow.js to be referenced here
+  webpackConfig.plugins.push(new SriPlugin({
+      hashFuncNames: ['sha256', 'sha384'],
+      // only enable it for non-development builds
+      enabled: !settings.isDevelopment(),
+  }));
+  return webpackConfig;
+}
+```
 ## FAQ
 
 ### How to setup a development environment to match the deployment environment?

--- a/packages/availity-workflow-angular/karma.conf.js
+++ b/packages/availity-workflow-angular/karma.conf.js
@@ -1,6 +1,6 @@
 const settings = require('availity-workflow-settings');
 
-const webpackConfig = require('./webpack.config.test');
+let webpackConfig = require('./webpack.config.test');
 
 if (settings.isCoverage()) {
   webpackConfig.module.rules.push({
@@ -11,6 +11,12 @@ if (settings.isCoverage()) {
     loader: 'istanbul-instrumenter-loader',
     options: { esModules: true }
   });
+}
+
+const { modifyWebpackConfig } = settings.config();
+
+if (typeof modifyWebpackConfig === 'function') {
+  webpackConfig = modifyWebpackConfig(webpackConfig, settings) || webpackConfig;
 }
 
 const karmaConfig = {

--- a/packages/availity-workflow-angular/karma.conf.sauce.js
+++ b/packages/availity-workflow-angular/karma.conf.sauce.js
@@ -1,6 +1,12 @@
 const settings = require('availity-workflow-settings');
 
-const webpackConfig = require('./webpack.config.test');
+let webpackConfig = require('./webpack.config.test');
+
+const { modifyWebpackConfig } = settings.config();
+
+if (typeof modifyWebpackConfig === 'function') {
+  webpackConfig = modifyWebpackConfig(webpackConfig, settings) || webpackConfig;
+}
 
 const karmaConfig = {
   basePath: settings.app(),

--- a/packages/availity-workflow/scripts/build.js
+++ b/packages/availity-workflow/scripts/build.js
@@ -21,7 +21,7 @@ function bundle(config) {
     // Check arguement or CLI arg or default to false
     const shouldProfile = (config && config.profile) || argv.profile || false;
 
-    const webpackConfig = shouldProfile ? plugin('webpack.config.profile') : plugin('webpack.config.production');
+    let webpackConfig = shouldProfile ? plugin('webpack.config.profile') : plugin('webpack.config.production');
 
     Logger.info('Started compiling');
     const spinner = ora('Running webpack');
@@ -44,6 +44,12 @@ function bundle(config) {
         }
       })
     );
+
+    const { modifyWebpackConfig } = settings.config();
+
+    if (typeof modifyWebpackConfig === 'function') {
+      webpackConfig = modifyWebpackConfig(webpackConfig, settings) || webpackConfig;
+    }
 
     webpack(webpackConfig).run((err, stats) => {
       spinner.stop();

--- a/packages/availity-workflow/scripts/start.js
+++ b/packages/availity-workflow/scripts/start.js
@@ -107,6 +107,12 @@ function web() {
       })
     );
 
+    const { modifyWebpackConfig } = settings.config();
+
+    if (typeof modifyWebpackConfig === 'function') {
+      webpackConfig = modifyWebpackConfig(webpackConfig, settings) || webpackConfig;
+    }
+
     const compiler = webpack(webpackConfig);
 
     compiler.plugin('invalid', () => {


### PR DESCRIPTION
Adds modifyWebpackConfig option to workflow.js. When it is a function it will be called with the current webpack config and a reference to the workflow settings
modifyWebpackConfig can be used to modify or replace the webpack config by returning the desiered final webpack config

Fixes #134, Fixes #146

This also allows many of the other "investigate webpack loader/plugin" tickets to be implemented by the user, but those tickets should remain open as they can be used to determine if those loaders/plugins should be included out of the box by default