### PR TITLE
case-sensitive-paths patch

### DIFF
--- a/packages/availity-react-kit/project/app/App.js
+++ b/packages/availity-react-kit/project/app/App.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BrowserRouter, Route } from 'react-router-dom';
-import AuthorizationRequest from './Request';
-import AuthorizationResponse from './Response';
+import AuthorizationRequest from './request';
+import AuthorizationResponse from './response';
 
 const App = () => (
   <BrowserRouter basename="/">


### PR DESCRIPTION
as written npm run start fails.  This should fix.

Error in ./project/app/App.js
Module not found: [CaseSensitivePathsPlugin] `/Users/jmacgowan/Developer/BONSAI/bonsai/packages/runbook-ui/project/app/Request/index.js` does not match the corresponding path on disk `request`.

 @ multi react-hot-loader/patch webpack-dev-server/client?http://localhost:3000 webpack/hot/only-dev-server ./index.js

✖  ERROR  Failed compiling