### PR TITLE
fix(availity-workflow): include 'node_modules' when searching for modules

### DIFF
--- a/packages/availity-workflow-angular/webpack.config.js
+++ b/packages/availity-workflow-angular/webpack.config.js
@@ -32,7 +32,7 @@ const config = {
 
   resolve: {
     // Tell webpack what directories should be searched when resolving modules
-    modules: [settings.app(), path.join(settings.project(), 'node_modules'), path.join(__dirname, 'node_modules')],
+    modules: [settings.app(), 'node_modules', path.join(settings.project(), 'node_modules'), path.join(__dirname, 'node_modules')],
 
     alias: {
       app: path.resolve(settings.app(), 'app-module')

--- a/packages/availity-workflow-angular/webpack.config.production.js
+++ b/packages/availity-workflow-angular/webpack.config.production.js
@@ -38,7 +38,7 @@ const config = {
 
   resolve: {
     // Tell webpack what directories should be searched when resolving modules
-    modules: [settings.app(), path.join(settings.project(), 'node_modules'), path.join(__dirname, 'node_modules')],
+    modules: [settings.app(), 'node_modules', path.join(settings.project(), 'node_modules'), path.join(__dirname, 'node_modules')],
     alias: {
       app: path.resolve(settings.app(), 'app-module')
     },

--- a/packages/availity-workflow-angular/webpack.config.profile.js
+++ b/packages/availity-workflow-angular/webpack.config.profile.js
@@ -37,7 +37,7 @@ const config = {
 
   resolve: {
     // Tell webpack what directories should be searched when resolving modules
-    modules: [settings.app(), path.join(settings.project(), 'node_modules'), path.join(__dirname, 'node_modules')],
+    modules: [settings.app(), 'node_modules', path.join(settings.project(), 'node_modules'), path.join(__dirname, 'node_modules')],
     symlinks: true,
     extensions: ['.js', '.jsx', '.json', '.css', 'scss']
   },

--- a/packages/availity-workflow-angular/webpack.config.test.js
+++ b/packages/availity-workflow-angular/webpack.config.test.js
@@ -37,7 +37,7 @@ const config = {
 
   resolve: {
     // Tell webpack what directories should be searched when resolving modules
-    modules: [settings.app(), path.join(settings.project(), 'node_modules'), path.join(__dirname, 'node_modules')],
+    modules: [settings.app(), 'node_modules', path.join(settings.project(), 'node_modules'), path.join(__dirname, 'node_modules')],
 
     alias: {
       app: path.resolve(settings.app(), 'app-module')

--- a/packages/availity-workflow-react/webpack.config.js
+++ b/packages/availity-workflow-react/webpack.config.js
@@ -48,7 +48,7 @@ const config = {
 
   resolve: {
     // Tell webpack what directories should be searched when resolving modules
-    modules: [settings.app(), path.join(settings.project(), 'node_modules'), path.join(__dirname, 'node_modules')],
+    modules: [settings.app(), 'node_modules', path.join(settings.project(), 'node_modules'), path.join(__dirname, 'node_modules')],
     symlinks: true,
     extensions: ['.js', '.jsx', '.json', '.css', 'scss']
   },

--- a/packages/availity-workflow-react/webpack.config.production.js
+++ b/packages/availity-workflow-react/webpack.config.production.js
@@ -37,7 +37,7 @@ const config = {
 
   resolve: {
     // Tell webpack what directories should be searched when resolving modules
-    modules: [settings.app(), path.join(settings.project(), 'node_modules'), path.join(__dirname, 'node_modules')],
+    modules: [settings.app(), 'node_modules', path.join(settings.project(), 'node_modules'), path.join(__dirname, 'node_modules')],
     symlinks: true,
     extensions: ['.js', '.jsx', '.json', '.css', 'scss']
   },

--- a/packages/availity-workflow-react/webpack.config.profile.js
+++ b/packages/availity-workflow-react/webpack.config.profile.js
@@ -36,7 +36,7 @@ const config = {
 
   resolve: {
     // Tell webpack what directories should be searched when resolving modules
-    modules: [settings.app(), path.join(settings.project(), 'node_modules'), path.join(__dirname, 'node_modules')],
+    modules: [settings.app(), 'node_modules', path.join(settings.project(), 'node_modules'), path.join(__dirname, 'node_modules')],
     symlinks: true,
     extensions: ['.js', '.jsx', '.json', '.css', 'scss']
   },


### PR DESCRIPTION
This back ports a change done to v3 to fix the same issue on v2.