### PR TITLE
fix(workflow): rename bin cmd to work with npx

### DIFF
--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "bin": {
     "av": "./index.js",
-    "@availity/workflow": "./index.js"
+    "workflow": "./index.js"
   },
   "scripts": {
     "test": "echo \"No test specified\" && exit 0",


### PR DESCRIPTION
based on https://github.com/zkat/npx/blob/6e89dbd5989366e52d3810692b1ab5889a05fbad/parse-args.js#L137-L138 npx will strip the package scope from the package name when looking for the command