### PR TITLE
fix: remove reduceIdents from css optimization

### DIFF
--- a/packages/workflow-plugin-angular/webpack.config.production.js
+++ b/packages/workflow-plugin-angular/webpack.config.production.js
@@ -204,7 +204,7 @@ if (settings.isProduction()) {
       }
     }),
     new OptimizeCSSAssetsPlugin({
-      cssProcessorOptions: { zindex: false }
+      cssProcessorOptions: { zindex: false, reduceIdents: false }
     })
   );
 }

--- a/packages/workflow-plugin-react/webpack.config.production.js
+++ b/packages/workflow-plugin-react/webpack.config.production.js
@@ -161,7 +161,7 @@ if (settings.isProduction()) {
       }
     }),
     new OptimizeCSSAssetsPlugin({
-      cssProcessorOptions: { zindex: false }
+      cssProcessorOptions: { zindex: false, reduceIdents: false }
     })
   );
 }


### PR DESCRIPTION
reduceIdents was causing collisions in keyframe names causing the wrong animations to run to PR removes that