### PR TITLE
feat/same-package | Create App In Current Directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "clean": "lerna clean --yes",
     "postinstall": "lerna bootstrap",
     "format": "prettier --write 'packages/*/*.js' 'packages/*/!(node_modules|dist)/**/*.js'",
-    "release": "npm run lint && npm run copy:templates && sh ./scripts/release.sh",
+    "release": "npm run lint && npm run copy:templates && lerna publish",
     "publishAll": "find ./packages -type d -maxdepth 1 -mindepth 1 -exec sh -c 'cd {} && npm publish' ';'",
     "copy:templates": "npm run copy:react:templates && npm run copy:angular:templates",
     "copy:angular:templates": "copyfiles -a -u 2 -e \"**/node_modules/**/*\" -e \"**/README.md\" \"packages/example-angular/**/*\" packages/workflow-plugin-angular/template/",

--- a/packages/workflow-plugin-angular/scripts/init.js
+++ b/packages/workflow-plugin-angular/scripts/init.js
@@ -43,6 +43,8 @@ module.exports = function init(
   const appPackage = require(path.join(appPath, 'package.json'));
 
   appPackage.name = appName;
+  appPackage.version = "0.1.0";
+  appPackage.private = true;
 
   fs.writeFileSync(
     path.join(appPath, 'package.json'),

--- a/packages/workflow-plugin-angular/scripts/init.js
+++ b/packages/workflow-plugin-angular/scripts/init.js
@@ -84,6 +84,8 @@ module.exports = function init(
   Logger.info('    Starts the test runner.');
   Logger.info()
   Logger.info('We suggest that you begin by typing:');
-  Logger.info(chalk.cyan(`  cd ${cdpath}`));
+  if(originalDirectory !== appPath) {
+    Logger.info(chalk.cyan(`  cd ${cdpath}`));
+  }
   Logger.info(`  ${chalk.cyan('npm start')}`);
 };

--- a/packages/workflow-plugin-react/scripts/init.js
+++ b/packages/workflow-plugin-react/scripts/init.js
@@ -43,6 +43,8 @@ module.exports = function init(
   const appPackage = require(path.join(appPath, 'package.json'));
 
   appPackage.name = appName;
+  appPackage.version = "0.1.0";
+  appPackage.private = true;
 
   fs.writeFileSync(
     path.join(appPath, 'package.json'),

--- a/packages/workflow-plugin-react/scripts/init.js
+++ b/packages/workflow-plugin-react/scripts/init.js
@@ -84,6 +84,8 @@ module.exports = function init(
   Logger.info('    Starts the test runner.');
   Logger.info()
   Logger.info('We suggest that you begin by typing:');
-  Logger.info(chalk.cyan(`  cd ${cdpath}`));
+  if(originalDirectory !== appPath) {
+    Logger.info(chalk.cyan(`  cd ${cdpath}`));
+  }
   Logger.info(`  ${chalk.cyan('npm start')}`);
 };

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -30,6 +30,7 @@ Show help menu for all CLI options.
 #### Options
 - `--package`, `-p`:  The framework/library @availity/workflow-plugin package you want to initialize with. [default: "react"]
 - `--version`, `-v`:  Specify which version of the package project you want. [default: "latest"]
+- `--current-dir`, `-c`: If you want the project to be created in the current directory
 
 #### Examples
 - `npx @availity/workflow init my-package-name`

--- a/packages/workflow/scripts/init.js
+++ b/packages/workflow/scripts/init.js
@@ -277,7 +277,11 @@ function createApp(name, package, version, currentDir) {
   const appName = path.basename(root);
 
   checkAppName(appName, package);
-  fs.ensureDirSync(name);
+
+  if(!currentDir) {
+    fs.ensureDirSync(name);
+  }
+
   if (!isSafeToCreateProjectIn(root, name)) {
     process.exit(1);
   }

--- a/packages/workflow/scripts/init.js
+++ b/packages/workflow/scripts/init.js
@@ -274,7 +274,7 @@ function run(root, package, appName, version, originalDirectory) {
 
 function createApp(name, package, version, currentDir) {
   const root = currentDir ? process.cwd() : path.resolve(name);
-  const appName = path.basename(root);
+  const appName = currentDir ? name : path.basename(root);
 
   checkAppName(appName, package);
 

--- a/packages/workflow/scripts/init.js
+++ b/packages/workflow/scripts/init.js
@@ -332,7 +332,7 @@ yargs
           chalk.yellow(`${chalk.yellow('av init')} ${chalk.green('my-app-name')} ${chalk.magenta('-p angular')}`)
         );
     },
-    ({ projectName, package, version }) => createApp(projectName, package, version, currentDir)
+    ({ projectName, package, version, currentDir }) => createApp(projectName, package, version, currentDir)
   )
   .example(chalk.yellow('av init my-app-name'))
   .example(chalk.yellow('av init my-app-name -p angular'));

--- a/packages/workflow/scripts/init.js
+++ b/packages/workflow/scripts/init.js
@@ -272,8 +272,8 @@ function run(root, package, appName, version, originalDirectory) {
     });
 }
 
-function createApp(name, package, version) {
-  const root = path.resolve(name);
+function createApp(name, package, version, currentDir) {
+  const root = currentDir ? process.cwd() : path.resolve(name);
   const appName = path.basename(root);
 
   checkAppName(appName, package);
@@ -321,13 +321,18 @@ yargs
           describe: 'Specify which version of the package project you want.',
           default: 'latest'
         })
+        .option('currentDir', {
+          alias: 'c',
+          describe: 'Pass this if you want to initialize the project in the same folder',
+          default: false
+        })
         .usage(`\nUsage: ${chalk.yellow('av init')} ${chalk.green('<projectName>')} ${chalk.magenta('[options]')}`)
         .example(chalk.yellow(`${chalk.yellow('av init')} ${chalk.green('my-app-name')}`))
         .example(
           chalk.yellow(`${chalk.yellow('av init')} ${chalk.green('my-app-name')} ${chalk.magenta('-p angular')}`)
         );
     },
-    ({ projectName, package, version }) => createApp(projectName, package, version)
+    ({ projectName, package, version }) => createApp(projectName, package, version, currentDir)
   )
   .example(chalk.yellow('av init my-app-name'))
   .example(chalk.yellow('av init my-app-name -p angular'));


### PR DESCRIPTION
Added ability to create the workflow project in the current directory by using the `--current-dir` or `-c` option in the cli.

Also fixed a minor bug where the project version wasn't being set to `0.1.0` when `fs.copySync` occurred.