### PR TITLE
Refactor/prepublish

### DIFF
--- a/packages/workflow-plugin-angular/package.json
+++ b/packages/workflow-plugin-angular/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "echo \"No test specified\" && exit 0",
     "test:integration": "echo \"No test specified\" && exit 0",
-    "prepublish": "npm run copy-template",
+    "prepublishOnly": "npm run copy-template",
     "copy-template": "copyfiles -a -u 2 -e \"../**/node_modules/**/*\" -e \"../**/README.md\" \"../example-angular/**/*\" template/"
   },
   "repository": {

--- a/packages/workflow-plugin-react/package.json
+++ b/packages/workflow-plugin-react/package.json
@@ -12,7 +12,7 @@
 		"workflow"
 	],
 	"scripts": {
-		"prepublish": "npm run copy-template",
+		"prepublishOnly": "npm run copy-template",
 		"copy-template": "copyfiles -a -u 2 -e \"../**/node_modules/**/*\" -e \"../**/README.md\" \"../example-react/**/*\" template/"
 	},
 	"author": "Robert McGuinness",


### PR DESCRIPTION
https://github.com/apiaryio/dredd/issues/945

`prepublish` is deprecated and we should be using `prepublishOnly` for pre-upload steps. `prepare` is for pre-build steps.