### PR TITLE
chore(example-react): bump @availity/reactstrap-validation-select to …

### DIFF
--- a/packages/example-react/package-lock.json
+++ b/packages/example-react/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@availity/example-react",
-	"version": "5.0.0",
+	"version": "5.2.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -48,16 +48,38 @@
 			}
 		},
 		"@availity/reactstrap-validation-select": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@availity/reactstrap-validation-select/-/reactstrap-validation-select-1.7.1.tgz",
-			"integrity": "sha512-4rmyKuX7xtSNDe6V10M+QYYYmgripoTUlpySs5X+fZ6w84tKUeEy8FwTkCxjvhO72Uo6AJYmbKDzyjHgsnUhZg==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@availity/reactstrap-validation-select/-/reactstrap-validation-select-3.0.0.tgz",
+			"integrity": "sha512-/shWLY5L7H0adl2tPKJtU+QUPszFypdNp6otGqSutBN5IgPQltpvygnKaUs0oEtZFWrMpzn5UvMJeuMfQKrJ9Q==",
 			"requires": {
 				"@thesharpieone/react-select-async-pagination": "^2.0.0",
 				"classnames": "^2.2.5",
-				"debounce": "^1.1.0",
 				"lodash": "^4.17.10",
 				"prop-types": "^15.5.8",
-				"qs": "^6.5.2"
+				"qs": "^6.5.2",
+				"react-select": "^2.4.2",
+				"react-select-async-paginate": "^0.2.9"
+			},
+			"dependencies": {
+				"memoize-one": {
+					"version": "5.0.4",
+					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.4.tgz",
+					"integrity": "sha512-P0z5IeAH6qHHGkJIXWw0xC2HNEgkx/9uWWBQw64FJj3/ol14VYdfVGWWr0fXfjhhv3TKVIqUq65os6O4GUNksA=="
+				},
+				"react-select": {
+					"version": "2.4.3",
+					"resolved": "https://registry.npmjs.org/react-select/-/react-select-2.4.3.tgz",
+					"integrity": "sha512-cmxNaiHpviRYkojeW9rGEUJ4jpX7QTmPe2wcscwA4d1lStzw/cJtr4ft5H2O/YhfpkrcwaLghu3XmEYdXhBo8Q==",
+					"requires": {
+						"classnames": "^2.2.5",
+						"emotion": "^9.1.2",
+						"memoize-one": "^5.0.0",
+						"prop-types": "^15.6.0",
+						"raf": "^3.4.0",
+						"react-input-autosize": "^2.2.1",
+						"react-transition-group": "^2.2.1"
+					}
+				}
 			}
 		},
 		"@babel/helper-module-imports": {
@@ -855,19 +877,6 @@
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.2.tgz",
 			"integrity": "sha512-Rl7PvTae0pflc1YtxtKbiSqq20Ts6vpIYOD5WBafl4y123DyHUeLrRdQP66sQW8/6gmX8jrYJLXwNeMqYVJcow=="
 		},
-		"d": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-			"requires": {
-				"es5-ext": "^0.10.9"
-			}
-		},
-		"debounce": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.0.tgz",
-			"integrity": "sha512-mYtLl1xfZLi1m4RtQYlZgJUNQjl4ZxVnHzIR8nLLgi4q1YT8o/WM+MK/f8yfcc9s5Ir5zRaPZyZU6xs1Syoocg=="
-		},
 		"debug": {
 			"version": "2.6.9",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -985,40 +994,6 @@
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"requires": {
 				"is-arrayish": "^0.2.1"
-			}
-		},
-		"es5-ext": {
-			"version": "0.10.47",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.47.tgz",
-			"integrity": "sha512-/1TItLfj+TTfWoeRcDn/0FbGV6SNo4R+On2GGVucPU/j3BWnXE2Co8h8CTo4Tu34gFJtnmwS9xiScKs4EjZhdw==",
-			"requires": {
-				"es6-iterator": "~2.0.3",
-				"es6-symbol": "~3.1.1",
-				"next-tick": "1"
-			}
-		},
-		"es6-iterator": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-			"requires": {
-				"d": "1",
-				"es5-ext": "^0.10.35",
-				"es6-symbol": "^3.1.1"
-			}
-		},
-		"es6-promise": {
-			"version": "4.2.6",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-			"integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
-		},
-		"es6-symbol": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-			"requires": {
-				"d": "1",
-				"es5-ext": "~0.10.14"
 			}
 		},
 		"escape-string-regexp": {
@@ -2380,11 +2355,6 @@
 				}
 			}
 		},
-		"next-tick": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
-			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
-		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -2758,6 +2728,15 @@
 					"resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.0.0.tgz",
 					"integrity": "sha512-7g0+ejkOaI9w5x6LvQwmj68kUj6rxROywPSCqmclG/HBacmFnZqhVscQ8kovkn9FBCNJmOz6SY42+jnvZzDWdw=="
 				}
+			}
+		},
+		"react-select-async-paginate": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/react-select-async-paginate/-/react-select-async-paginate-0.2.9.tgz",
+			"integrity": "sha512-4Rb+0+zpb0u49ubRZcj+imDb0lw8y59dnugk1lyJSmHdTSrUfJWEsz5VGT3rgLYxsjPzqY3Z/xVrrj8ZHpFxPA==",
+			"requires": {
+				"@babel/runtime": "^7.2.0",
+				"prop-types": "^15.7.2"
 			}
 		},
 		"react-testing-library": {

--- a/packages/example-react/package.json
+++ b/packages/example-react/package.json
@@ -37,7 +37,7 @@
     "@availity/env-var": "^1.6.0",
     "@availity/localstorage-core": "^2.5.0",
     "@availity/reactstrap-validation-date": "^1.7.1",
-    "@availity/reactstrap-validation-select": "^1.6.0",
+    "@availity/reactstrap-validation-select": "^3.0.0",
     "@reach/router": "^1.2.1",
     "availity-reactstrap-validation": "^2.0.2",
     "availity-uikit": "^3.0.0",


### PR DESCRIPTION
…v3.0.0

bumps `@availity/reactstrap-validation-select` package to `^v3.0.0`

`react-select-async-paginate` does have a peer dependency of `react-select@^2.0.0`: https://github.com/vtaits/react-select-async-paginate/blob/master/package.json#L23

which we are already compliant with: https://github.com/Availity/availity-workflow/blob/master/packages/example-react/package.json#L53