### PR TITLE
Remove unnecessary imports from components index.js files.

### DIFF
--- a/packages/example-react/project/app/Request/components/index.js
+++ b/packages/example-react/project/app/Request/components/index.js
@@ -1,5 +1,3 @@
-import Agreement from './Agreement';
-import Patient from './Patient';
-import Provider from './Provider';
-
-export { Agreement, Patient, Provider };
+export { Agreement } from './Agreement';
+export { Patient } from './Patient';
+export { Provider } from './Provider';

--- a/packages/example-react/project/app/Request/components/index.js
+++ b/packages/example-react/project/app/Request/components/index.js
@@ -1,3 +1,3 @@
-export { Agreement } from './Agreement';
-export { Patient } from './Patient';
-export { Provider } from './Provider';
+export { default as Agreement } from './Agreement';
+export { default as Patient } from './Patient';
+export { default as Provider } from './Provider';

--- a/packages/example-react/project/app/Response/components/index.js
+++ b/packages/example-react/project/app/Response/components/index.js
@@ -1,5 +1,3 @@
-import Status from './Status';
-import Patient from './Patient';
-import Transaction from './Transaction';
-
-export { Transaction, Patient, Status };
+export { Status } from './Status';
+export { Patient } from './Patient';
+export { Transaction } from './Transaction';

--- a/packages/example-react/project/app/Response/components/index.js
+++ b/packages/example-react/project/app/Response/components/index.js
@@ -1,3 +1,3 @@
-export { Status } from './Status';
-export { Patient } from './Patient';
-export { Transaction } from './Transaction';
+export { default as Status } from './Status';
+export { default as Patient } from './Patient';
+export { default as Transaction } from './Transaction';


### PR DESCRIPTION
The previous implementation may seem cleaner to import everything and then export on a single line.

Curious to hear what others think on the matter if this change is accepted it can b applied to other areas in the project.

Alternative option 1 might be:

export { Transaction, Patient, Status } from '.';
Alternative option 2 might be:

export { Transaction, Patient, Status } from './*';
The alternative options would suffer if multiple files in the same directory exported the same component name. However the standard in react is to export components with the same name as the filename. If that is the case there would be no issues with the alternative options.