### PR TITLE
docs: add contribute to the table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
 *   [Configuration](#configuration)
 *   [Upgrading](#upgrading)
 *   [FAQ](#faq)
+*   [CONTRIBUTE](#contribute)
+*   [DISCLAIMER](#disclaimer)
 *   [License](#license)
 
 ## Getting Started


### PR DESCRIPTION
Contribute was not in the table of contents, trying to help a contributor see the contribute section in case they did not scroll to the bottom of the readme.

For this project it is important that a contributor reads through the entire readme.

However, when groking the Readme there are two very challenging sections to the first timer. Configuration and FAQ.

A contributor needs to temporarily skip these parts to get to the all important Contribute section that tells them how to run locally without scaffolding a new react or angular app.

Putting contribute in the table of contents allows another path to that documentation.

Contribute
```
Run npm install
Run npm run bootstrap at project root
Use npm run angular to start the Angular sample application
Use npm run react to use the React sample application
```