### PR TITLE
refactor(example-react): added tsconfig file to ignore warnings

### DIFF
--- a/packages/example-react/tsconfig.json
+++ b/packages/example-react/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+      "experimentalDecorators": true,
+      "allowJs": true
+  }
+}


### PR DESCRIPTION
Experimental Decorators are enabled per babel config and should not raise warnings to users in their IDEs


closes #218 