### PR TITLE
fix(workflow-settings): revert css loader to v2

### DIFF
--- a/packages/workflow-plugin-react/package.json
+++ b/packages/workflow-plugin-react/package.json
@@ -31,7 +31,7 @@
 		"chalk": "^2.3.2",
 		"copy-webpack-plugin": "^4.5.1",
 		"cross-spawn": "^6.0.5",
-		"css-loader": "^3.1.0",
+		"css-loader": "2.1.1",
 		"duplicate-package-checker-webpack-plugin": "^3.0.0",
 		"eslint-config-availity": "^4.0.0",
 		"eslint-loader": "^2.1.1",

--- a/packages/workflow-settings/webpack/loader-css.js
+++ b/packages/workflow-settings/webpack/loader-css.js
@@ -11,9 +11,8 @@ module.exports = {
         options: {
           sourceMap: true,
           importLoaders: 1,
-          modules: {
-            localIdentName: 'images/[name].[ext]'
-          }
+          localIdentName: 'images/[name].[ext]'
+
         }
       },
       loaderPostcss
@@ -33,9 +32,8 @@ module.exports = {
         options: {
           sourceMap: true,
           importLoaders: 1,
-          modules: {
-            localIdentName: 'images/[name].[ext]'
-          }
+          localIdentName: 'images/[name].[ext]'
+
         }
       },
       loaderPostcss


### PR DESCRIPTION
v3 of the `css-loader` threw unwanted errors. Until this can be resolved fully through other dep upgrades/configs getting this bug fix in.

```
✖  ERROR  Failed compiling
(node:5383) UnhandledPromiseRejectionWarning: CssSyntaxError: /Users/<user>/Workspaces/<project-name>/<repo-name>/css/vendor-cd4a327eed7fc2d6d76c.css:164:32: Missed semicolon
    at Input.error (/Users/<user>/Workspaces/<project-name>/<repo-name>/node_modules/postcss/lib/input.js:130:16)
    at Parser.checkMissedSemicolon (
```