### PR TITLE
fix proxy body write condition

### DIFF
--- a/packages/workflow/scripts/proxy.js
+++ b/packages/workflow/scripts/proxy.js
@@ -77,7 +77,7 @@ function onResponse(proxyConfig, proxyObject, req, res) {
   });
 
   const isJson = typeIs.is(proxyObject.headers['content-type'], ['json']) === 'json';
-  if (isJson && !proxyObject.statusCode === 304) {
+  if (isJson && proxyObject.statusCode !== 304) {
     proxyJson(res, proxyObject.headers['content-encoding'], body => {
       if (body) {
         const json = JSON.stringify(body);


### PR DESCRIPTION
AFAICT the current condition can never be true?

![image](https://user-images.githubusercontent.com/664714/67707100-4208f180-f990-11e9-9cd7-4d4174c6005e.png)
![image](https://user-images.githubusercontent.com/664714/67707172-65cc3780-f990-11e9-8b41-b14cd192f226.png)

With this change, it will be true when `proxyObject.statusCode` is not 304
![image](https://user-images.githubusercontent.com/664714/67707263-8bf1d780-f990-11e9-86ff-eb698f37e42f.png)
![image](https://user-images.githubusercontent.com/664714/67707283-9613d600-f990-11e9-948d-9ed7664719e4.png)
