### PR TITLE
fix(workflow): only add ReactRefreshWebpackPlugin if hotLoader experi…

### DIFF
--- a/packages/workflow/webpack.config.js
+++ b/packages/workflow/webpack.config.js
@@ -115,9 +115,6 @@ const plugin = settings => {
 
       // Generate hot module chunks
       new webpack.HotModuleReplacementPlugin(),
-      new ReactRefreshWebpackPlugin({
-        disableRefreshCheck: true
-      }),
 
       new HtmlWebpackPlugin(html(settings)),
 
@@ -147,6 +144,14 @@ const plugin = settings => {
       )
     ]
   };
+
+  if (settings.getHotLoaderName() === 'react-refresh/babel') {
+    config.plugins.push(
+      new ReactRefreshWebpackPlugin({
+        disableRefreshCheck: true
+      })
+    );
+  }
 
   if (settings.isNotifications()) {
     config.plugins.push(


### PR DESCRIPTION
Fixes `react-refresh` files being loaded when `config.development.hotLoader.experimental` is `false`