### PR TITLE
add support for HEAD requests in mock-server

### DIFF
--- a/packages/mock-server/response/index.js
+++ b/packages/mock-server/response/index.js
@@ -4,6 +4,8 @@ const patch = require('./patch');
 
 const response = {
   get: get.send,
+  
+  head: get.send,
 
   delete: get.send,
 


### PR DESCRIPTION
the mock-data server doesn't handle HEAD requests even through they should get essentially be treated the same as GET
