### PR TITLE
Updated with missing command

### DIFF
--- a/docs/source/tutorial/index.md
+++ b/docs/source/tutorial/index.md
@@ -13,13 +13,14 @@ The minimum required [Nodejs](https://nodejs.org/) version to run and use our to
 
 Our toolkit has a built in CLI that will allow you to run multiple commands like you would with any other react project. In addition to the default commands you would see like `start`, `test`, `build` we have an `init` command that will initialize a new project using a [specified default template](/reference/commands/#availity-templates).
 
-You can run the below command to get started:
+You can run the below commands to get started:
 
 ```bash
 npx @availity/workflow init workflow-app
+yarn add @availity/mock-server --dev
 ```
 
-What the above command is doing is using [npx](https://www.npmjs.com/package/npx) to download and execute the script without you having a pre-existing `package.json`. The `init` command is the command we send to our package `@availity/workflow`. The last argument, `workflow-app` is the project name that we gave.
+What the above commands are doing is using [npx](https://www.npmjs.com/package/npx) to download and execute the script without you having a pre-existing `package.json`. The `init` command is the command we send to our package `@availity/workflow`. The last argument, `workflow-app` is the project name that we gave.
 
 Once the CLI finishes initializing the project we can `cd` into the directory with the below command:
 


### PR DESCRIPTION
If you try and run the above steps without the add you receive the error: 

 Failed to create Ekko Server. Please install '@availity/mock-server' with `yarn install @availity/mock-server --dev` or check your settings

but yarn install is depreciated so yarn add is the proper command.

**Before submitting a pull request,** please make sure the following is done:

1. Fork [the repository](https://github.com/availity/availity-react) and create your branch from `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
8. Make sure your code passed the conventional commits check. Read more about [conventional commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary)
