### PR TITLE
fix testMatch regex to work correctly on windows

### DIFF
--- a/packages/workflow/jest.config.js
+++ b/packages/workflow/jest.config.js
@@ -56,7 +56,7 @@ function create(settings) {
       // dist
       //   - the dist output directory
       '<rootDir>/!(build|docs|dist|node_modules|scripts)/**/__tests__/**/*.(js|ts|tsx)?(x)',
-      '<rootDir>/!(build|docs|dist|node_modules|scripts)/**/?(*.)(spec|test).(js|ts|tsx)?(x)'
+      '<rootDir>/!(build|docs|dist|node_modules|scripts)/**/*(*.)(spec|test).(js|ts|tsx)?(x)'
     ],
     globals: settings.globals()
   };


### PR DESCRIPTION
 - This PR fixes the regex for the test matcher in the jest config so windows can properly detect and run unit tests with jest when using this package.