### PR TITLE
fix(workflow): fixes issue with Windows paths being incompatible with…

### DIFF
--- a/packages/workflow/settings/index.js
+++ b/packages/workflow/settings/index.js
@@ -43,7 +43,8 @@ const settings = {
   ekkoServerPort: null,
 
   app() {
-    return path.join(this.project(), 'project/app');
+    // https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows
+    return path.join(this.project(), 'project/app').replace(/\\/g, '/');
   },
 
   include() {


### PR DESCRIPTION
… globby

Converts backslashes to forwardslashes according to https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows