### PR TITLE
Fix/windows path

### DIFF
--- a/packages/workflow/scripts/lint.js
+++ b/packages/workflow/scripts/lint.js
@@ -67,7 +67,7 @@ function lint() {
 
     // Uses globby which defaults to process.cwd() and path.resolve(options.cwd, "/")
     /* eslint-disable promise/catch-or-return */
-    globby(settings.js()).then(paths => {
+    globby(settings.js().map(path => path.replace(/\\/g, '/'))).then(paths => {
       spinner.stop();
       const filesToLint = gitTrackedFiles
         ? // git repository present

--- a/packages/workflow/settings/index.js
+++ b/packages/workflow/settings/index.js
@@ -43,8 +43,7 @@ const settings = {
   ekkoServerPort: null,
 
   app() {
-    // https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows
-    return path.join(this.project(), 'project/app').replace(/\\/g, '/');
+    return path.join(this.project(), 'project/app');
   },
 
   include() {


### PR DESCRIPTION
Reverts change in #446 , which fixed the `lint` script on windows, but broke the `start` script. Applies same `replace` fix in the `lint` script so as not to affect other scripts. 
