### PR TITLE
Fix/workflow upgrade

### DIFF
--- a/packages/workflow-upgrade/index.js
+++ b/packages/workflow-upgrade/index.js
@@ -5,15 +5,33 @@ const rimraf = require('rimraf');
 const { exec } = require('child_process');
 const Logger = require('@availity/workflow-logger');
 
-module.exports = cwd => {
+module.exports = (cwd) => {
   Logger.info('Upgrading @availity/workflow');
   const pkgFile = path.join(cwd, 'package.json');
 
   if (fs.existsSync(pkgFile)) {
     // Read Package File to JSON
     const pkg = readPkg.sync({ cwd, normalize: false });
-
     const { devDependencies, scripts } = pkg;
+    const pkgLock = path.join(cwd, 'package-lock.json');
+    const yarnLock = path.join(cwd, 'yarn.lock');
+    let installer = '';
+    let peerInfoReceived = false;
+
+    if (fs.existsSync(pkgLock)) {
+      // delete package lock, set npm install command
+      Logger.info('Deleting Package-Lock');
+      fs.unlinkSync(pkgLock);
+      installer = 'npm';
+    } else if (fs.existsSync(yarnLock)) {
+      // delete yarn lock, set yarn install command
+      Logger.info('Deleting yarn.lock');
+      fs.unlinkSync(yarnLock);
+      installer = 'yarn';
+    } else {
+      Logger.warn('No lockfile detected, setting yarn as default installer.');
+      installer = 'yarn';
+    }
 
     // Add this script into the new workflow scripts for the future
     scripts['upgrade:workflow'] = './node_modules/.bin/upgrade-workflow';
@@ -33,26 +51,22 @@ module.exports = cwd => {
       delete devDependencies['eslint-plugin-react'];
       delete devDependencies['@availity/workflow-plugin-react'];
       delete devDependencies['@availity/workflow-plugin-angular'];
+
+      // Get needed dependencies from eslint-config-availity
+      Logger.info('Adding peerDependencies from eslint-config-availity to devDependencies');
+      exec(`${installer} info eslint-config-availity peerDependencies`, (error, stdout, stderr) => {
+        if (!error && !stderr && stdout) {
+          // Both npm and yarn will return an object containing key/value pairs of dependencies
+          Object.assign(devDependencies, stdout);
+          peerInfoReceived = true;
+        } else {
+          Logger.warn('Failed to get peerDependencies from eslint-config-availity');
+        }
+      });
     }
 
     // Update package.json
     fs.writeFileSync(pkgFile, `${JSON.stringify(pkg, null, 2)}\n`, 'utf-8');
-
-    let installer = '';
-    const pkgLock = path.join(cwd, 'package-lock.json');
-    const yarnLock = path.join(cwd, 'yarn.lock');
-
-    if (fs.existsSync(pkgLock)) {
-      // delete package lock, set npm install command
-      Logger.info('Deleting Package-Lock');
-      fs.unlinkSync(pkgLock);
-      installer = 'npm';
-    } else if (fs.existsSync(yarnLock)) {
-      // delete yarn lock, set yarn install command
-      Logger.info('Deleting yarn.lock');
-      fs.unlinkSync(yarnLock);
-      installer = 'yarn';
-    }
 
     Logger.info('Deleting node modules...');
     // Delete Node Modules
@@ -63,6 +77,11 @@ module.exports = cwd => {
       // Run install command
       exec(`${installer} install`, () => {
         Logger.success('\nCongratulations! Welcome to the new @availity/workflow.');
+        if (!peerInfoReceived) {
+          Logger.info(
+            'To complete your upgrade, please install the peerDependencies from eslint-config-availity as devDependencies in your project.'
+          );
+        }
       });
     };
 

--- a/packages/workflow-upgrade/package.json
+++ b/packages/workflow-upgrade/package.json
@@ -27,8 +27,9 @@
   },
   "homepage": "https://github.com/availity/availity-workflow#readme",
   "engines": {
-    "node": ">= 8.0.0",
-    "npm": ">= 4.0.0"
+    "node": ">= 10.22.0",
+    "npm": ">= 6.4.1",
+    "yarn": ">=1.22.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -113,7 +113,8 @@
   },
   "engines": {
     "node": ">= 10.22.0",
-    "npm": ">= 6.4.1"
+    "npm": ">= 6.4.1",
+    "yarn": ">1.22.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Needed a way to grab peer dependencies from `eslint-config-availity` that are needed for React apps but not necessarily Node apps. These peer dependencies are present for new apps initialized with Workflow, but have been missing from upgraded apps. Without them, users are currently unable to upgrade a workflow project and then lint using the default configuration.