### PR TITLE
Refactor/optional chaining

### DIFF
--- a/example/project/__test__/App.test.tsx
+++ b/example/project/__test__/App.test.tsx
@@ -1,12 +1,25 @@
 import React from 'react';
-import { render, waitForElement } from '@testing-library/react';
+import { render } from '@testing-library/react';
+import { chain, nullChain } from '@/chain';
 import App from '../app/App';
 
-
-describe("App", () => {
-  test('renders without error', async () => {
+describe('App', () => {
+  test('renders without error', () => {
     const { getByText } = render(<App />);
+    expect(getByText('Test Card Header')).toBeDefined();
+  });
 
-    await waitForElement(() => getByText('Test Card Header'));
-  })
-})
+  test('optional chaining field has initial value', () => {
+    // This test makes sure you are at least developing using a newer version of Node
+    // You will still need to test transpiled code
+    const { getByDisplayValue } = render(<App />);
+    expect(getByDisplayValue(chain)).toBeDefined();
+  });
+
+  test('nullish coalesced field has initial value', () => {
+    // This test makes sure you are at least developing using a newer version of Node
+    // You will still need to test transpiled code
+    const { getByDisplayValue } = render(<App />);
+    expect(getByDisplayValue(nullChain)).toBeDefined();
+  });
+});

--- a/example/project/app/App.tsx
+++ b/example/project/app/App.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { Formik } from 'formik';
 import PageHeader from '@availity/page-header';
 import { Container, Card } from 'reactstrap';
-import * as yup from 'yup';
+import { object, string } from 'yup';
 import Form from '@/components/Form';
-import chain from '@/chain';
+import { chain, nullChain } from '@/chain';
 
 const App: React.SFC<{}> = () => (
   <Container className="container-sm">
@@ -14,14 +14,17 @@ const App: React.SFC<{}> = () => (
       initialValues={{
         formField: '',
         chainedField: chain,
+        nullishCoalescedField: nullChain,
       }}
       // onSubmit={() => {}}
-      validationSchema={yup.object().shape({
-        formField: yup.string().required('This field is required.'),
-        chainedField: yup.string().required('This field is required.'),
+      validationSchema={object().shape({
+        formField: string().required('This field is required.'),
+        chainedField: string().required('This field is required.'),
+        nullishCoalescedField: string().required('This field is required.'),
       })}
-      render={Form}
-    />
+    >
+      {Form}
+    </Card>
   </Container>
 );
 

--- a/example/project/app/chain.js
+++ b/example/project/app/chain.js
@@ -1,4 +1,4 @@
-// Simple .js file to test compiling and linting for @babel/plugin-proposal-optional-chaining
+// Simple .js file to test compiling and linting for @babel/plugin-proposal-optional-chaining and @babel/plugin-proposal-nullish-coalescing-operator
 
 const chainObject = {
   org: {
@@ -10,5 +10,5 @@ const chainObject = {
   },
 };
 
-const chain = chainObject.org?.types?.[0]?.name;
-export default chain;
+export const chain = chainObject.org?.types?.[0]?.name;
+export const nullChain = chainObject.org?.types?.[0]?.value ?? 'iWasCoalesced!';

--- a/example/project/app/components/Form.tsx
+++ b/example/project/app/components/Form.tsx
@@ -12,6 +12,7 @@ const Form: React.SFC<FormikProps<FormValues>> = ({ handleSubmit, handleReset })
     <CardBody>
       <Field name="formField" label="Some Field Label" />
       <Field name="chainedField" label="Another Field Label" />
+      <Field name="nullishCoalescedField" label="Yet Another Field Label" />
     </CardBody>
     <CardFooter className="d-flex justify-content-end">
       <Button color="secondary" onClick={handleReset}>

--- a/packages/workflow/babel-preset.js
+++ b/packages/workflow/babel-preset.js
@@ -32,8 +32,7 @@ module.exports = (_api, opts) => {
           rootPathSuffix: 'project/app',
           rootPathPrefix: '@/'
         }
-      ],
-      [require.resolve('@babel/plugin-proposal-optional-chaining')]
+      ]
     ].filter(Boolean)
   };
 };

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -27,7 +27,6 @@
   "dependencies": {
     "@availity/workflow-logger": "^5.5.9",
     "@babel/core": "^7.11.6",
-    "@babel/plugin-proposal-optional-chaining": "^7.6.0",
     "@babel/runtime": "^7.7.2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.4.2",
     "@testing-library/jest-dom": "^5.11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -716,7 +716,7 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-syntax-optional-chaining" "^7.8.0"
 
-"@babel/plugin-proposal-optional-chaining@^7.11.0", "@babel/plugin-proposal-optional-chaining@^7.6.0", "@babel/plugin-proposal-optional-chaining@^7.9.0":
+"@babel/plugin-proposal-optional-chaining@^7.11.0", "@babel/plugin-proposal-optional-chaining@^7.9.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz#de5866d0646f6afdaab8a566382fe3a221755076"
   integrity sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==


### PR DESCRIPTION
Removes optional chaining plugin since it and nullish coalescing have become a part of babel-preset-react-app https://github.com/facebook/create-react-app/blob/master/packages/babel-preset-react-app/package.json#L27-L29