### PR TITLE
feat(workflow): add polyfill for Array.prototype.includes()

### DIFF
--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -77,6 +77,7 @@
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "ora": "^5.1.0",
     "path-browserify": "^1.0.1",
+    "polyfill-array-includes": "^2.0.0",
     "postcss": "^8.0.9",
     "postcss-flexbugs-fixes": "^4.1.0",
     "postcss-focus": "^5.0.0",

--- a/packages/workflow/webpack.config.js
+++ b/packages/workflow/webpack.config.js
@@ -33,6 +33,7 @@ const plugin = (settings) => {
     entry: {
       index: [
         require.resolve('react-app-polyfill/ie11'),
+        require.resolve('polyfill-array-includes'),
         `${require.resolve('webpack-dev-server/client')}?/`,
         require.resolve('webpack/hot/dev-server'),
         require.resolve('navigator.sendbeacon'),

--- a/packages/workflow/webpack.config.production.js
+++ b/packages/workflow/webpack.config.production.js
@@ -32,6 +32,7 @@ const plugin = (settings) => {
     entry: {
       index: [
         require.resolve('react-app-polyfill/ie11'),
+        require.resolve('polyfill-array-includes'),
         require.resolve('navigator.sendbeacon'),
         resolveModule(resolveApp, 'index')
       ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -16145,6 +16145,11 @@ pnp-webpack-plugin@^1.6.4:
   dependencies:
     ts-pnp "^1.1.6"
 
+polyfill-array-includes@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/polyfill-array-includes/-/polyfill-array-includes-2.0.0.tgz#a160d85de1a7eec4be0fd67da1c5030b699d2429"
+  integrity sha512-HTrB0xYCN3TgOQvk5Tc7ehhl0vC73DARlhNMIDF8xCdPwPOELAYEZkgqJp0vbUGnM3FvcaXgxrwLw+bzKepI2A==
+
 popper.js@^1.14.4:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"


### PR DESCRIPTION
Fixes `@availity/hooks` issues in IE 11 due to react-query needing this polyfill for its `isDocumentVisible()` function