### PR TITLE
docs: fix broken Upgrading link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,9 @@ modifyWebpackConfig: (webpackConfig, settings) => {
 };
 ```
 
-## Upgrading <small>[[Credit](https://github.com/typicode/husky/tree/master/src/upgrader)]</small>
+## Upgrading
+
+[[Credit](https://github.com/typicode/husky/tree/master/src/upgrader)]
 
 Change to the directory you want to upgrade the workflow for and run the below command.
 


### PR DESCRIPTION
Markdown did not like having the credit link in the Header. It applied the href tag correctly as #upgrading-credit, but the link didn't work. So I just moved the credit down a line
