### PR TITLE
fix(workflow-upgrade): fixes eslint-config-availity not being installed

### DIFF
--- a/packages/workflow-upgrade/index.js
+++ b/packages/workflow-upgrade/index.js
@@ -42,9 +42,7 @@ module.exports = async (cwd) => {
 
     // Check for deprecated workflow features
     if (availityWorkflow.plugin) {
-      Logger.warn(`Deprecated plugin feature detected, removing availityWorkflow.plugin entry.
-        If you are not configuring workflow via package.json, please add "availityWorkflow": true, in its place.`);
-
+      Logger.warn(`Deprecated plugin feature detected, removing availityWorkflow.plugin entry.`);
       delete availityWorkflow.plugin;
     }
 

--- a/packages/workflow-upgrade/index.js
+++ b/packages/workflow-upgrade/index.js
@@ -40,12 +40,18 @@ module.exports = async (cwd) => {
     // Add this script into the new workflow scripts for the future
     scripts['upgrade:workflow'] = './node_modules/.bin/upgrade-workflow';
 
-    if (!availityWorkflow) {
-      Object.assign(pkg, { availityWorkflow: true });
-    } else if (availityWorkflow.plugin) {
+    // Check for deprecated workflow features
+    if (availityWorkflow.plugin) {
       Logger.warn(`Deprecated plugin feature detected, removing availityWorkflow.plugin entry.
-      If you are not configuring workflow via package.json, please add "availityWorkflow": true, in its place.`);
+        If you are not configuring workflow via package.json, please add "availityWorkflow": true, in its place.`);
+
       delete availityWorkflow.plugin;
+    }
+
+    // If workflow entry didn't exist, or plugin was its only key
+    if (!availityWorkflow || Object.keys(availityWorkflow).length === 0) {
+      Logger.info(`Adding '"availityWorkflow": true' to package.json`);
+      Object.assign(pkg, { availityWorkflow: true });
     }
 
     if (devDependencies) {


### PR DESCRIPTION
`npx @availity-workflow-upgrade` respects semver in `package.json` even though it deletes the project's lockfile. This is fine for all dependencies, except for `@availity/workflow`. If user is running the upgrade command, they should be upgraded to latest and greatest, not latest within semver.

Also fixes case where `eslint-config-availity` was not being installed if missing from the project. I believe we were running a synchronous command when we should have been awaiting its result