### PR TITLE
fix: set sourceType to unambiguous

### DIFF
--- a/packages/workflow/babel-preset.js
+++ b/packages/workflow/babel-preset.js
@@ -16,6 +16,8 @@ module.exports = (_api, opts) => {
   const isEnvProduction = env === 'production';
 
   return {
+    // Don't assume ESM. Check if file is cjs
+    sourceType: 'unambiguous',
     presets: [[require.resolve('babel-preset-react-app')]],
     plugins: [
       isEnvProduction && [


### PR DESCRIPTION
This fixes an issue with `babel` assuming files under `@availity` scope will be esm. I believe this was originally set since our libs did not ship transpiled code. Setting `sourceType` to `unambiguous` will fix the issue

Credit: https://github.com/babel/babel/issues/12731 