### PR TITLE
chore: update semver plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@commitlint/cli": "^15.0.0",
     "@commitlint/config-angular": "^16.2.1",
     "@commitlint/config-conventional": "^15.0.0",
-    "@jscutlery/semver": "^2.21.6",
+    "@jscutlery/semver": "^2.25.2",
     "@nrwl/cli": "13.10.1",
     "@nrwl/js": "^13.10.2",
     "@nrwl/workspace": "13.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4271,16 +4271,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jscutlery/semver@npm:^2.21.6":
-  version: 2.21.6
-  resolution: "@jscutlery/semver@npm:2.21.6"
+"@jscutlery/semver@npm:^2.25.2":
+  version: 2.25.2
+  resolution: "@jscutlery/semver@npm:2.25.2"
   dependencies:
-    "@nrwl/devkit": 13.9.2
-    "@nrwl/workspace": 13.9.2
-    inquirer: 8.2.2
+    inquirer: 8.2.4
     rxjs: 7.5.5
-    standard-version: 9.3.2
-  checksum: bc7c4e70367c3155780638447b07a497b6b06784247d0c91964e8c65eba6e1e54fdea56d5c4d4b90e9d837cc00b7793528e5b07b912fa84af6416dd1a56a4f79
+    standard-version: 9.5.0
+  peerDependencies:
+    "@nrwl/devkit": ^14.0.0
+  checksum: 35071a3838eb4078fe62dadf1fde2f0a5d6c1ba2b53d99e574bfc5c5b843ed575526330063c005979beca99b0a7559e1709e43775c566208cbd4fb0bf3590850
   languageName: node
   linkType: hard
 
@@ -4416,17 +4416,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nrwl/cli@npm:13.9.2":
-  version: 13.9.2
-  resolution: "@nrwl/cli@npm:13.9.2"
-  dependencies:
-    nx: 13.9.2
-  bin:
-    nx: bin/nx.js
-  checksum: ce1e577c24a3caf26e2941381e70ea286825a9ee9e61290155e1dc7741c68726eeb475c30825ecf823acafc385b0aae891fee84318c2f98a6683b8fdbfd893aa
-  languageName: node
-  linkType: hard
-
 "@nrwl/devkit@npm:13.10.1":
   version: 13.10.1
   resolution: "@nrwl/devkit@npm:13.10.1"
@@ -4452,20 +4441,6 @@ __metadata:
     semver: 7.3.4
     tslib: ^2.3.0
   checksum: d30426e3046a98ebc56009796a9230f56c767fb49b1e2c4f57efc180667685a8563acf74b29659e7a06a5bd6ac847d3753203d1619a3c6c4c4fc37d962163c83
-  languageName: node
-  linkType: hard
-
-"@nrwl/devkit@npm:13.9.2":
-  version: 13.9.2
-  resolution: "@nrwl/devkit@npm:13.9.2"
-  dependencies:
-    ejs: ^3.1.5
-    ignore: ^5.0.4
-    nx: 13.9.2
-    rxjs: ^6.5.4
-    semver: 7.3.4
-    tslib: ^2.3.0
-  checksum: d87179230358669f3263418e3759a9957c28c4effb78416d1b48a4b9946fb4dd8c9d7f39f4be0725e2e92d5f26b1fa9388a2cf2cea51007e1f882d67dd9ac5df
   languageName: node
   linkType: hard
 
@@ -4504,25 +4479,6 @@ __metadata:
     rxjs: ^6.5.4
     tslib: ^2.3.0
   checksum: 30837b9283c26f5e06f736948e993984cb5be47e7b0841969b1076262b880b4dca3052ba1544314746497a5d5873b3fa54f7d3ca4f97a16a5f31f8b94ac0180c
-  languageName: node
-  linkType: hard
-
-"@nrwl/jest@npm:13.9.2":
-  version: 13.9.2
-  resolution: "@nrwl/jest@npm:13.9.2"
-  dependencies:
-    "@jest/reporters": 27.2.2
-    "@jest/test-result": 27.2.2
-    "@nrwl/devkit": 13.9.2
-    chalk: 4.1.0
-    identity-obj-proxy: 3.0.0
-    jest-config: 27.2.2
-    jest-resolve: 27.2.2
-    jest-util: 27.2.0
-    resolve.exports: 1.1.0
-    rxjs: ^6.5.4
-    tslib: ^2.3.0
-  checksum: 5fe4f6839a5a6797db3772d3501be89f70dd120c3364ccc593aa7cb16bed611bc576b50346350ca65c0cffdee377eef8362770a674ec8b9a5651b90805b32ddb
   languageName: node
   linkType: hard
 
@@ -4583,24 +4539,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nrwl/linter@npm:13.9.2":
-  version: 13.9.2
-  resolution: "@nrwl/linter@npm:13.9.2"
-  dependencies:
-    "@nrwl/devkit": 13.9.2
-    "@nrwl/jest": 13.9.2
-    "@phenomnomnominal/tsquery": 4.1.1
-    tmp: ~0.2.1
-    tslib: ^2.3.0
-  peerDependencies:
-    eslint: ^8.0.0
-  peerDependenciesMeta:
-    eslint:
-      optional: true
-  checksum: b7a7d60ee4fbd4b734d2ee2c15ee6ea562e22f9258c8f197687c8d481ead9d610f6a18ef244ba263dcfbca4f7eebe39f23d23f5905873599c336a1e4ba82b03b
-  languageName: node
-  linkType: hard
-
 "@nrwl/tao@npm:13.10.1":
   version: 13.10.1
   resolution: "@nrwl/tao@npm:13.10.1"
@@ -4620,17 +4558,6 @@ __metadata:
   bin:
     tao: index.js
   checksum: 0bdd96c7c689cfd83f7bee1e8d33daa07df8188dfb7902d19121ab7ab505abf50cd3c4dcfb111fda73e1971cb1db3747e511cc51fd11ecda88dafff9818252ae
-  languageName: node
-  linkType: hard
-
-"@nrwl/tao@npm:13.9.2":
-  version: 13.9.2
-  resolution: "@nrwl/tao@npm:13.9.2"
-  dependencies:
-    nx: 13.9.2
-  bin:
-    tao: index.js
-  checksum: af3eb197d2888edfe3d5d29f99915050175df7e1864027d3c209666a2de205b5a095559bdab205ee87da5256e182ded8e17a30f2d0de5705aa4d5c005314beaf
   languageName: node
   linkType: hard
 
@@ -4707,44 +4634,6 @@ __metadata:
     prettier:
       optional: true
   checksum: 5779c559d15163272e63c8b00d2839b08d979a599581708bb092b9a6861c5531ce190e8d033056b8f4f7e92f6baca654c8e5056d7eda859c1076da58b30929d7
-  languageName: node
-  linkType: hard
-
-"@nrwl/workspace@npm:13.9.2":
-  version: 13.9.2
-  resolution: "@nrwl/workspace@npm:13.9.2"
-  dependencies:
-    "@nrwl/devkit": 13.9.2
-    "@nrwl/jest": 13.9.2
-    "@nrwl/linter": 13.9.2
-    "@parcel/watcher": 2.0.4
-    chalk: 4.1.0
-    chokidar: ^3.5.1
-    cli-cursor: 3.1.0
-    cli-spinners: 2.6.1
-    dotenv: ~10.0.0
-    enquirer: ~2.3.6
-    figures: 3.2.0
-    flat: ^5.0.2
-    fs-extra: ^9.1.0
-    glob: 7.1.4
-    ignore: ^5.0.4
-    minimatch: 3.0.4
-    npm-run-path: ^4.0.1
-    nx: 13.9.2
-    open: ^8.4.0
-    rxjs: ^6.5.4
-    semver: 7.3.4
-    tmp: ~0.2.1
-    tslib: ^2.3.0
-    yargs: 15.4.1
-    yargs-parser: 20.0.0
-  peerDependencies:
-    prettier: ^2.5.1
-  peerDependenciesMeta:
-    prettier:
-      optional: true
-  checksum: 7e8fd96d902f34eabbe57dbb24e57a2d8bc08783e2a5b94af1c9c1de121b79238c92b313db7b9518d2ed1696533f440f501b851e27b68702bc57be2911b2fc92
   languageName: node
   linkType: hard
 
@@ -5126,7 +5015,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/core@npm:^1.2.119, @swc/core@npm:^1.2.146, @swc/core@npm:^1.2.152":
+"@swc/core@npm:^1.2.119, @swc/core@npm:^1.2.152":
   version: 1.2.165
   resolution: "@swc/core@npm:1.2.165"
   dependencies:
@@ -7240,7 +7129,7 @@ __metadata:
     "@commitlint/cli": ^15.0.0
     "@commitlint/config-angular": ^16.2.1
     "@commitlint/config-conventional": ^15.0.0
-    "@jscutlery/semver": ^2.21.6
+    "@jscutlery/semver": ^2.25.2
     "@nrwl/cli": 13.10.1
     "@nrwl/js": ^13.10.2
     "@nrwl/workspace": 13.10.1
@@ -8891,17 +8780,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cliui@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "cliui@npm:6.0.0"
-  dependencies:
-    string-width: ^4.2.0
-    strip-ansi: ^6.0.0
-    wrap-ansi: ^6.2.0
-  checksum: 4fcfd26d292c9f00238117f39fc797608292ae36bac2168cfee4c85923817d0607fe21b3329a8621e01aedf512c99b7eaa60e363a671ffd378df6649fb48ae42
-  languageName: node
-  linkType: hard
-
 "cliui@npm:^7.0.2":
   version: 7.0.4
   resolution: "cliui@npm:7.0.4"
@@ -9345,14 +9223,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-conventionalcommits@npm:4.6.1, conventional-changelog-conventionalcommits@npm:^4.6.1":
-  version: 4.6.1
-  resolution: "conventional-changelog-conventionalcommits@npm:4.6.1"
+"conventional-changelog-conventionalcommits@npm:4.6.3":
+  version: 4.6.3
+  resolution: "conventional-changelog-conventionalcommits@npm:4.6.3"
   dependencies:
     compare-func: ^2.0.0
     lodash: ^4.17.15
     q: ^1.5.1
-  checksum: f866616c8f6f21cea005b42792451bfbd16bd4d82872867d1218f67a7993a53c5d87e26d6b483d9252e8022f2e4570e6cf9fa2a409aae5a3d73eea92ccf78b13
+  checksum: 7b8e8a21ebb56f9aaa510e12917b7c609202072c3e71089e0a09630c37c2e8146cdb04364809839b0e3eb55f807fe84d03b2079500b37f6186d505848be5c562
   languageName: node
   linkType: hard
 
@@ -9375,6 +9253,17 @@ __metadata:
     lodash: ^4.17.15
     q: ^1.5.1
   checksum: e11944881f123f26a92e823a96e4d921b03203a312da9d539773c424103b49917f59fa717a079738f4d5b0e9709b0336ec323a86a56df7d008663b01e5f8b3b9
+  languageName: node
+  linkType: hard
+
+"conventional-changelog-conventionalcommits@npm:^4.6.1":
+  version: 4.6.1
+  resolution: "conventional-changelog-conventionalcommits@npm:4.6.1"
+  dependencies:
+    compare-func: ^2.0.0
+    lodash: ^4.17.15
+    q: ^1.5.1
+  checksum: f866616c8f6f21cea005b42792451bfbd16bd4d82872867d1218f67a7993a53c5d87e26d6b483d9252e8022f2e4570e6cf9fa2a409aae5a3d73eea92ccf78b13
   languageName: node
   linkType: hard
 
@@ -9474,7 +9363,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog@npm:3.1.24, conventional-changelog@npm:^3.1.24":
+"conventional-changelog@npm:3.1.25":
+  version: 3.1.25
+  resolution: "conventional-changelog@npm:3.1.25"
+  dependencies:
+    conventional-changelog-angular: ^5.0.12
+    conventional-changelog-atom: ^2.0.8
+    conventional-changelog-codemirror: ^2.0.8
+    conventional-changelog-conventionalcommits: ^4.5.0
+    conventional-changelog-core: ^4.2.1
+    conventional-changelog-ember: ^2.0.9
+    conventional-changelog-eslint: ^3.0.9
+    conventional-changelog-express: ^2.0.6
+    conventional-changelog-jquery: ^3.0.11
+    conventional-changelog-jshint: ^2.0.9
+    conventional-changelog-preset-loader: ^2.3.4
+  checksum: 1ea18378120cca9fd459f58ed2cf59170773cbfb2fcecad2504c7c44af076c368950013fa16f5e9428f1d723bea4c16e0c48170e152568b73b254a9c1bb93287
+  languageName: node
+  linkType: hard
+
+"conventional-changelog@npm:^3.1.24":
   version: 3.1.24
   resolution: "conventional-changelog@npm:3.1.24"
   dependencies:
@@ -13019,15 +12927,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-access@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "fs-access@npm:1.0.1"
-  dependencies:
-    null-check: ^1.0.0
-  checksum: 6792b115a5fc5095b3dbc42ea329afff372e0056fde8214a5b0c9c7559806378db9316660bac1682b295cc576bab3c19571f50f8a39ab4605c3d194bee0087c9
-  languageName: node
-  linkType: hard
-
 "fs-constants@npm:^1.0.0":
   version: 1.0.0
   resolution: "fs-constants@npm:1.0.0"
@@ -14803,9 +14702,9 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"inquirer@npm:8.2.2":
-  version: 8.2.2
-  resolution: "inquirer@npm:8.2.2"
+"inquirer@npm:8.2.4":
+  version: 8.2.4
+  resolution: "inquirer@npm:8.2.4"
   dependencies:
     ansi-escapes: ^4.2.1
     chalk: ^4.1.1
@@ -14821,7 +14720,8 @@ fsevents@~2.1.2:
     string-width: ^4.1.0
     strip-ansi: ^6.0.0
     through: ^2.3.6
-  checksum: 69a2cf32f51af0e94dd66c597fdca42b890ff521b537dbfe1fd532c19a751d54893b7896523691ec30357f6212a80a2417fec7bf34411f369bbf151bdbc95ae9
+    wrap-ansi: ^7.0.0
+  checksum: dfcb6529d3af443dfea2241cb471508091b51f5121a088fdb8728b23ec9b349ef0a5e13a0ef2c8e19457b0bed22f7cbbcd561f7a4529d084c562a58c605e2655
   languageName: node
   linkType: hard
 
@@ -19023,13 +18923,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"null-check@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "null-check@npm:1.0.0"
-  checksum: 6569fb2d74399e436eb4b05c7fdd341f22e87f3e0598a97309681073a364d6684997100cd329f2107d149663c506b2bfa47a0afdff23739ac1ba6ca5c4c6aa19
-  languageName: node
-  linkType: hard
-
 "null-loader@npm:^3.0.0":
   version: 3.0.0
   resolution: "null-loader@npm:3.0.0"
@@ -19142,34 +19035,6 @@ fsevents@~2.1.2:
   bin:
     nx: bin/nx.js
   checksum: 862f8653403a3d6f1d048fbb6979c4d55d65b82e684892d5fba14fd4ebcfad88b61efbc644f55b68cdbda46ac3d1db67ca9906e6572c7b69ab3c49bee4bb672d
-  languageName: node
-  linkType: hard
-
-"nx@npm:13.9.2":
-  version: 13.9.2
-  resolution: "nx@npm:13.9.2"
-  dependencies:
-    "@nrwl/cli": 13.9.2
-    "@nrwl/tao": 13.9.2
-    "@swc-node/register": ^1.4.2
-    "@swc/core": ^1.2.146
-    chalk: 4.1.0
-    enquirer: ~2.3.6
-    fast-glob: 3.2.7
-    fs-extra: ^9.1.0
-    ignore: ^5.0.4
-    jsonc-parser: 3.0.0
-    rxjs: ^6.5.4
-    rxjs-for-await: 0.0.2
-    semver: 7.3.4
-    tmp: ~0.2.1
-    tsconfig-paths: ^3.9.0
-    tslib: ^2.3.0
-    v8-compile-cache: 2.3.0
-    yargs-parser: 20.0.0
-  bin:
-    nx: bin/nx.js
-  checksum: 3c844c30c8801f9fd17d0d10541e833d891a989807d4711599c610b5e5e4731442a44a21d09800d84173b2699ebc16e50d5bce7e375ff03fe58f24562d5432fd
   languageName: node
   linkType: hard
 
@@ -24577,28 +24442,27 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"standard-version@npm:9.3.2":
-  version: 9.3.2
-  resolution: "standard-version@npm:9.3.2"
+"standard-version@npm:9.5.0":
+  version: 9.5.0
+  resolution: "standard-version@npm:9.5.0"
   dependencies:
     chalk: ^2.4.2
-    conventional-changelog: 3.1.24
+    conventional-changelog: 3.1.25
     conventional-changelog-config-spec: 2.1.0
-    conventional-changelog-conventionalcommits: 4.6.1
+    conventional-changelog-conventionalcommits: 4.6.3
     conventional-recommended-bump: 6.1.0
     detect-indent: ^6.0.0
     detect-newline: ^3.1.0
     dotgitignore: ^2.1.0
     figures: ^3.1.0
     find-up: ^5.0.0
-    fs-access: ^1.0.1
     git-semver-tags: ^4.0.0
     semver: ^7.1.1
     stringify-package: ^1.0.1
     yargs: ^16.0.0
   bin:
     standard-version: bin/cli.js
-  checksum: 40e1105b73e77105338a869096708e15aebf0c1104740f8cbbbb24173f55a8e7f221ff2e4cad4765c230d34094caa4e378ceb74a1ea890709c32f5fb67bd49b7
+  checksum: 55003206f7eca18ee9962566e5222d3930a1fa3c4692615d64e88f08873b9685837d669dc58361831bd3f211b6687c1681ad6a1749edf346b2db3e4564b4933c
   languageName: node
   linkType: hard
 
@@ -27430,13 +27294,6 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:20.0.0":
-  version: 20.0.0
-  resolution: "yargs-parser@npm:20.0.0"
-  checksum: 8a5e4bd50c09beb8aeed386b5c81b98310ff34f76cf0c120f7490caf9bb0218648c5cd53973fabb8c39f317f4df4e0318b1823f006be562f7202ce819c1bcc52
-  languageName: node
-  linkType: hard
-
 "yargs-parser@npm:21.0.1, yargs-parser@npm:^21.0.0":
   version: 21.0.1
   resolution: "yargs-parser@npm:21.0.1"
@@ -27454,7 +27311,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^18.1.2, yargs-parser@npm:^18.1.3":
+"yargs-parser@npm:^18.1.3":
   version: 18.1.3
   resolution: "yargs-parser@npm:18.1.3"
   dependencies:
@@ -27468,25 +27325,6 @@ resolve@^2.0.0-next.3:
   version: 20.2.4
   resolution: "yargs-parser@npm:20.2.4"
   checksum: d251998a374b2743a20271c2fd752b9fbef24eb881d53a3b99a7caa5e8227fcafd9abf1f345ac5de46435821be25ec12189a11030c12ee6481fef6863ed8b924
-  languageName: node
-  linkType: hard
-
-"yargs@npm:15.4.1":
-  version: 15.4.1
-  resolution: "yargs@npm:15.4.1"
-  dependencies:
-    cliui: ^6.0.0
-    decamelize: ^1.2.0
-    find-up: ^4.1.0
-    get-caller-file: ^2.0.1
-    require-directory: ^2.1.1
-    require-main-filename: ^2.0.0
-    set-blocking: ^2.0.0
-    string-width: ^4.2.0
-    which-module: ^2.0.0
-    y18n: ^4.0.0
-    yargs-parser: ^18.1.2
-  checksum: 40b974f508d8aed28598087720e086ecd32a5fd3e945e95ea4457da04ee9bdb8bdd17fd91acff36dc5b7f0595a735929c514c40c402416bbb87c03f6fb782373
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update the @jscutlery/semver plugin to avoid removing new line in package.json when version is bumped
