### PR TITLE
Dependabot workflows

### DIFF
--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -1,16 +1,11 @@
-# This workflow has access to secrets and a read token
+# This job has access to secrets and a read token
 name: Dependabot Build
-on:
-  workflow_run:
-    workflows: ['Dependabot PR Check']
-    types:
-      - completed
-
-permissions: write-all # TODO: figure out appropriate permissions
+on: pull_request
 
 jobs:
   build:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    permissions: write-all # TODO: figure out appropriate permissions
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/dependabot-build.yml
+++ b/.github/workflows/dependabot-build.yml
@@ -1,4 +1,4 @@
-# This job has access to secrets and a read token
+# This workflow has access to dependabot secrets and a read token
 name: Dependabot Build
 on: pull_request
 


### PR DESCRIPTION
Current dependabot workflows have builds trigger off another workflow instead of the pull_request trigger. The pattern was recommended back when they first pulled access to secrets from dependabot. However, this seems to prevent the statuses of the builds from being linked to the PR. 

They have since added separate secrets explicitly for dependabot. We should now be able to trigger directly from pull_request and if any secrets are needed add them to dependabot as needed.
