### PR TITLE
build: fix versioning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,7 +129,7 @@ jobs:
           yarn config set npmAuthToken "${{ secrets.NPM_TOKEN }}"
           git config --global user.email ${{ secrets.GH_EMAIL }}
           git config --global user.name ${{ secrets.GH_USER }}
-          yarn nx affected --target version --baseBranch master --parallel=1
+          yarn version
           yarn nx affected --target publish
           git push && git push --tags
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Integration Test Affected Code
         run: yarn nx affected --target=integration
 
+      - name: Version Bump Dry Run
+        run: yarn version:dry-run
+
       - name: Build Docs (Node 16+ only)
         if: ${{matrix.node > 14}}
         run: yarn build:docs

--- a/package.json
+++ b/package.json
@@ -25,13 +25,15 @@
     "start:docs": "yarn workspace @availity/dinosaurdocs start",
     "test": "jest --silent",
     "test:app": "yarn workspace @availity/example test",
-    "test:integration": "yarn workspaces foreach -i -v run integration --verbose"
+    "test:integration": "yarn workspaces foreach -i -v run integration --verbose",
+    "version": "nx affected --target version --parallel=1",
+    "version:dry-run": "nx affected --target version --dryRun --parallel=1"
   },
   "devDependencies": {
     "@commitlint/cli": "^15.0.0",
     "@commitlint/config-angular": "^16.3.0",
     "@commitlint/config-conventional": "^15.0.0",
-    "@jscutlery/semver": "^2.30.1",
+    "@jscutlery/semver": "2.29.3",
     "@nrwl/cli": "13.10.6",
     "@nrwl/js": "^13.10.6",
     "@nrwl/workspace": "13.10.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5572,19 +5572,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jscutlery/semver@npm:^2.30.1":
-  version: 2.30.1
-  resolution: "@jscutlery/semver@npm:2.30.1"
+"@jscutlery/semver@npm:2.29.3":
+  version: 2.29.3
+  resolution: "@jscutlery/semver@npm:2.29.3"
   dependencies:
     chalk: 4.1.2
     conventional-changelog: ^3.1.25
     conventional-recommended-bump: ^6.1.0
     detect-indent: 6.1.0
     inquirer: 8.2.5
-    rxjs: 7.8.0
+    rxjs: 7.6.0
   peerDependencies:
     "@nrwl/devkit": ^15.0.0
-  checksum: 8e4219c49214746b9a75d4a0c96cc8d2bfa1f375bd26c849fde3601416b3c1a67f86f92f4755486697ffbb0e616b6d12f11f8b90410910a5732b2f396e80facf
+  checksum: c69813276d9e4c98309b77cbaf5e5dea64033cbbe065e90c855a00999f21b9a524a4b09cc6188aab84a202e9a38fc94d9c170a192fbac123c76f92171a1119e4
   languageName: node
   linkType: hard
 
@@ -8116,7 +8116,7 @@ __metadata:
     "@commitlint/cli": ^15.0.0
     "@commitlint/config-angular": ^16.3.0
     "@commitlint/config-conventional": ^15.0.0
-    "@jscutlery/semver": ^2.30.1
+    "@jscutlery/semver": 2.29.3
     "@nrwl/cli": 13.10.6
     "@nrwl/js": ^13.10.6
     "@nrwl/workspace": 13.10.6
@@ -21141,12 +21141,12 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"rxjs@npm:7.8.0":
-  version: 7.8.0
-  resolution: "rxjs@npm:7.8.0"
+"rxjs@npm:7.6.0":
+  version: 7.6.0
+  resolution: "rxjs@npm:7.6.0"
   dependencies:
     tslib: ^2.1.0
-  checksum: 61b4d4fd323c1043d8d6ceb91f24183b28bcf5def4f01ca111511d5c6b66755bc5578587fe714ef5d67cf4c9f2e26f4490d4e1d8cabf9bd5967687835e9866a2
+  checksum: b3abbbfe1ddfd06fca9314b83cbd13bcddc3320429218136f75c79a4802ac430dd13873364aac1ded54fd457f8c77df332d205a92d8a1c61656565bb718c50af
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
There was an issue with the new version of `@jscutlery/semver` so I reverted the version and added the `version` and `version:dry-run` scripts
