### PR TITLE
fix(workflow): replace file-loader with asset/resource

### DIFF
--- a/packages/workflow/webpack.config.production.js
+++ b/packages/workflow/webpack.config.production.js
@@ -146,7 +146,7 @@ const plugin = (settings) => {
               test: /font\.(woff|woff2|eot|ttf|otf|svg)$/i,
               type: 'asset/resource',
               generator: {
-                filename: 'fonts/[name].[ext]'
+                filename: 'fonts/[name][ext]'
               }
             },
             loaders.images,
@@ -156,14 +156,14 @@ const plugin = (settings) => {
             // This loader doesn't use a "test" so it will catch all modules
             // that fall through the other loaders.
             {
-              loader: require.resolve('file-loader'),
+              type: 'asset/resource',
               // Exclude `js` files to keep "css" loader working as it injects
               // its runtime that would otherwise be processed through "file" loader.
               // Also exclude `html` and `json` extensions so they get processed
               // by webpack's internal loaders.
               exclude: [/\.(js|cjs|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
-              options: {
-                name: 'static/media/[name:200].[contenthash:8].[ext]'
+              generator: {
+                filename: 'static/media/[contenthash:8][ext]'
               }
             }
           ]


### PR DESCRIPTION
file-loader doesn't work in Node 17+ and deprecated in Webpack 5+

**Before submitting a pull request,** please make sure the following is done:

1. If you are part of the Availity organization, clone this repository and create your branch off of `master`. If you are not part of the organization, you will need to fork this repository and the create your branch off of `master`.
2. Run `yarn` in the repository root.
3. If you've fixed a bug or added code that should be tested, add tests!
4. Ensure the test suite passes (`yarn test`). Tip: `yarn test --watch TestName` is helpful in development.
5. Make sure your code passed the conventional commits check. Read more about [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
