### PR TITLE
chore(workflow): add esm packages to jest transform ignore

### DIFF
--- a/packages/workflow/jest.config.js
+++ b/packages/workflow/jest.config.js
@@ -19,7 +19,7 @@ function create(settings) {
 
   // Allow developers to add their own node_modules include path
   const userInclude = settings.configuration.development.babelInclude;
-  const includes = ['@av','axios', ...userInclude].join('|');
+  const includes = ['@av','axios', '@tanstack', 'is-what', 'copy-anything', ...userInclude].join('|');
 
   const userJestOverrides = settings.configuration.development.jestOverrides;
 


### PR DESCRIPTION
we were updating some of our dependencies to use the new tanstack react-query and found some bumps with newer ESM packages that no longer need to be transformed by jest, so we thought adding them to the default jest config might be nice too ;)
