### PR TITLE
fix(workflow-upgrade): fix error getting peerDeps and buffer overflow

### DIFF
--- a/packages/workflow-upgrade/package.json
+++ b/packages/workflow-upgrade/package.json
@@ -39,7 +39,11 @@
   },
   "dependencies": {
     "@availity/workflow-logger": "workspace:*",
+    "inquirer": "^8.2.5",
     "read-pkg": "^5.2.0",
     "rimraf": "^5.0.1"
+  },
+  "devDependencies": {
+    "@types/inquirer": "^8"
   }
 }

--- a/packages/workflow-upgrade/project.json
+++ b/packages/workflow-upgrade/project.json
@@ -6,7 +6,7 @@
       "executor": "@jscutlery/semver:version",
       "options": {
         "preset": "angular",
-        "commitMessageFormat": "chore(${projectName}): release version ${version}",
+        "commitMessageFormat": "chore(${projectName}): release version ${version} [skip ci]",
         "tagPrefix": "@availity/${projectName}@"
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,6 +777,8 @@ __metadata:
   resolution: "@availity/workflow-upgrade@workspace:packages/workflow-upgrade"
   dependencies:
     "@availity/workflow-logger": "workspace:*"
+    "@types/inquirer": ^8
+    inquirer: ^8.2.5
     read-pkg: ^5.2.0
     rimraf: ^5.0.1
   bin:
@@ -8729,6 +8731,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/inquirer@npm:^8":
+  version: 8.2.10
+  resolution: "@types/inquirer@npm:8.2.10"
+  dependencies:
+    "@types/through": "*"
+    rxjs: ^7.2.0
+  checksum: e576823345146e939e93e06fc5a81baa5231f0113b669191155cd5f5925b3e897d3a3c42c0be8b3e7b0b188b7e05d1cf42011cc2da4d123f7e58940caf9cd17f
+  languageName: node
+  linkType: hard
+
 "@types/is-ci@npm:^3.0.0":
   version: 3.0.0
   resolution: "@types/is-ci@npm:3.0.0"
@@ -9113,6 +9125,15 @@ __metadata:
   dependencies:
     "@types/jest": "*"
   checksum: f2ed81103acb52d54f992d826e3854551294618628997dc01f8955efd8c1d476d64715b79187371b09ec3e61e44cc10a7ffe1e427d1bda798552f83d18309056
+  languageName: node
+  linkType: hard
+
+"@types/through@npm:*":
+  version: 0.0.33
+  resolution: "@types/through@npm:0.0.33"
+  dependencies:
+    "@types/node": "*"
+  checksum: fd0b73f873a64ed5366d1d757c42e5dbbb2201002667c8958eda7ca02fff09d73de91360572db465ee00240c32d50c6039ea736d8eca374300f9664f93e8da39
   languageName: node
   linkType: hard
 
@@ -24936,7 +24957,7 @@ resolve@^2.0.0-next.3:
   languageName: node
   linkType: hard
 
-"rxjs@npm:7.8.1, rxjs@npm:^7.8.0":
+"rxjs@npm:7.8.1, rxjs@npm:^7.2.0, rxjs@npm:^7.8.0":
   version: 7.8.1
   resolution: "rxjs@npm:7.8.1"
   dependencies:


### PR DESCRIPTION
This pr started with trying to fix a bug where an error was thrown because the call to get peerDeps was failing because the lockfile was already deleted. I fixed this issue and also added some enhancements

- Added logs
- Increased the max buffer size for the exec call to install node_modules (I was running into a buffer overflow issue)
- Changed the way the latest version of `@availity/workflow` and `eslint-config-availity` is calculated. We now use npm to get latest version