### PR TITLE
fix(workflow): check for tsconfig.json before adding plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ reports/
 !.yarn/sdks
 !.yarn/versions
 .pnp.*
+
+.nx/cache

--- a/packages/workflow/helpers/paths.js
+++ b/packages/workflow/helpers/paths.js
@@ -10,5 +10,6 @@ module.exports = {
   project: resolveApp(''),
   app: resolveApp('project/app'),
   appNodeModules: resolveApp('node_modules'),
-  appStatic: resolveApp('project/app/static')
+  appStatic: resolveApp('project/app/static'),
+  tsconfig: resolveApp('tsconfig.json')
 };

--- a/packages/workflow/scripts/build.js
+++ b/packages/workflow/scripts/build.js
@@ -23,7 +23,14 @@ function bundle({ profile, settings }) {
     // Check argument or CLI arg or default to false
     const shouldProfile = profile || argv.profile || false;
 
-    let webpackConfig = shouldProfile ? webpackConfigProfile(settings) : webpackConfigProduction(settings);
+    let webpackConfig;
+    try {
+      webpackConfig = shouldProfile ? webpackConfigProfile(settings) : webpackConfigProduction(settings);
+    } catch (error) {
+      Logger.error(`There was an error creating the Webpack config: ${error.message}`);
+      reject(error.message);
+      return;
+    }
 
     Logger.info('Started compiling');
     const spinner = ora('Running webpack');

--- a/packages/workflow/webpack.config.js
+++ b/packages/workflow/webpack.config.js
@@ -21,8 +21,12 @@ process.noDeprecation = true;
 const buildBaseConfig = (settings) => {
   const resolveApp = (relativePath) => path.resolve(settings.app(), relativePath);
 
-  function getVersion() {
-    return settings.pkg().version || 'N/A';
+  const getVersion = () => settings.pkg().version || 'N/A';
+
+  // Check for tsconfig.json
+  const resolvePlugins = [];
+  if (fs.existsSync(paths.tsconfig)) {
+    resolvePlugins.push(new TsconfigPathsPlugin({ extensions: ['.js', '.jsx', '.ts', '.tsx'] }));
   }
 
   const config = {
@@ -58,7 +62,7 @@ const buildBaseConfig = (settings) => {
       fallback: {
         path: require.resolve('path-browserify')
       },
-      plugins: [new TsconfigPathsPlugin({ extensions: ['.js', '.jsx', '.ts', '.tsx'] })]
+      plugins: resolvePlugins
     },
     // This set of options is identical to the resolve property set above,
     // but is used only to resolve webpack's loader packages.


### PR DESCRIPTION
Adds a check for `tsconfig.json` before adding the tsconfig paths plugin. Also added a try/catch to not swallow errors in the future
