### PR TITLE
fix: replace require() with dynamic import() in vite config for ESM compatibility

### DIFF
--- a/packages/workflow/scripts/build.js
+++ b/packages/workflow/scripts/build.js
@@ -109,7 +109,7 @@ async function bundleVite({ settings }) {
     fs.rmSync(settings.output(), { recursive: true, force: true });
   }
 
-  let viteConfig = buildViteProductionConfig(settings);
+  let viteConfig = await buildViteProductionConfig(settings);
 
   const { modifyViteConfig } = settings.config();
   if (typeof modifyViteConfig === 'function') {

--- a/packages/workflow/scripts/start.js
+++ b/packages/workflow/scripts/start.js
@@ -221,7 +221,7 @@ async function webVite() {
   const { createServer } = await import('vite');
   const { default: buildViteConfig } = await import('../vite.config.js');
 
-  let viteConfig = buildViteConfig(settings);
+  let viteConfig = await buildViteConfig(settings);
 
   const { modifyViteConfig } = settings.config();
   if (typeof modifyViteConfig === 'function') {

--- a/packages/workflow/tests/workflowConfigs.spec.js
+++ b/packages/workflow/tests/workflowConfigs.spec.js
@@ -2,6 +2,8 @@ import settings from '../settings/index.js';
 import baseConfig from '../webpack.config.js';
 import prodConfig from '../webpack.config.production.js';
 import profileConfig from '../webpack.config.profile.js';
+import buildViteConfig from '../vite.config.js';
+import buildViteProductionConfig from '../vite.config.production.js';
 
 const NOW = '2023-03-28T16:07:07.909Z';
 
@@ -31,5 +33,24 @@ describe('webpack configs', () => {
   it('sets up the profile config with default settings', () => {
     const config = profileConfig(settings);
     expect(stabilizePaths(config)).toMatchSnapshot();
+  });
+});
+
+describe('vite configs', () => {
+  beforeAll(async () => {
+    await settings.init();
+  });
+
+  it('resolves the vite dev config without ERR_REQUIRE_ESM', async () => {
+    const config = await buildViteConfig(settings);
+    expect(config).toBeDefined();
+    expect(config.root).toBeDefined();
+    expect(config.plugins.length).toBeGreaterThan(0);
+  });
+
+  it('resolves the vite production config without ERR_REQUIRE_ESM', async () => {
+    const config = await buildViteProductionConfig(settings);
+    expect(config).toBeDefined();
+    expect(config.build).toBeDefined();
   });
 });

--- a/packages/workflow/vite.config.js
+++ b/packages/workflow/vite.config.js
@@ -1,13 +1,11 @@
-import { createRequire } from 'module';
 import fs from 'fs';
 import path from 'path';
+import Logger from '@availity/workflow-logger';
 import { toViteProxy } from './scripts/proxy.js';
 import paths from './helpers/paths.js';
 import resolveModule from './helpers/resolve-module.js';
 
-const require = createRequire(import.meta.url);
-
-const buildViteConfig = (settings) => {
+const buildViteConfig = async (settings) => {
   const resolveApp = (relativePath) => path.resolve(settings.app(), relativePath);
   const getVersion = () => settings.pkg().version || 'N/A';
 
@@ -30,22 +28,22 @@ const buildViteConfig = (settings) => {
   // SWC-based React plugin — 20-70x faster JSX/TS transforms than Babel-based alternative.
   // Falls back to @vitejs/plugin-react (Babel) if SWC plugin isn't installed.
   try {
-    const reactSwc = require('@vitejs/plugin-react-swc');
+    const { default: reactSwc } = await import('@vitejs/plugin-react-swc');
     plugins.push(reactSwc());
   } catch {
-    const react = require('@vitejs/plugin-react');
+    const { default: react } = await import('@vitejs/plugin-react');
     plugins.push(react());
   }
 
   // tsconfig paths support (replaces TsconfigPathsPlugin)
   if (fs.existsSync(paths.tsconfig)) {
-    const tsconfigPaths = require('vite-tsconfig-paths');
+    const { default: tsconfigPaths } = await import('vite-tsconfig-paths');
     plugins.push(tsconfigPaths());
   }
 
   // Static file copying (replaces CopyWebpackPlugin)
   if (fs.existsSync(paths.appStatic)) {
-    const { viteStaticCopy } = require('vite-plugin-static-copy');
+    const { viteStaticCopy } = await import('vite-plugin-static-copy');
     plugins.push(
       viteStaticCopy({
         targets: [
@@ -60,7 +58,7 @@ const buildViteConfig = (settings) => {
 
   // ESLint integration (replaces ESLintPlugin)
   try {
-    const eslintPlugin = require('vite-plugin-checker');
+    const { default: eslintPlugin } = await import('vite-plugin-checker');
     plugins.push(
       eslintPlugin({
         eslint: {
@@ -180,7 +178,6 @@ const buildViteConfig = (settings) => {
 
       for (const [pkgName, locations] of packages) {
         if (locations.size > 1) {
-          const Logger = require('@availity/workflow-logger');
           Logger.warn(
             `Duplicate package: ${pkgName} bundled from ${locations.size} locations:\n${
             [...locations].map((loc) => `  - ${loc}`).join('\n')

--- a/packages/workflow/vite.config.production.js
+++ b/packages/workflow/vite.config.production.js
@@ -1,8 +1,8 @@
 import deepMerge from './helpers/deep-merge.js';
 import buildViteConfig from './vite.config.js';
 
-const buildViteProductionConfig = (settings) => {
-  const baseConfig = buildViteConfig(settings);
+const buildViteProductionConfig = async (settings) => {
+  const baseConfig = await buildViteConfig(settings);
 
   const productionOverrides = {
     build: {


### PR DESCRIPTION
## Problem

  When using `config.bundler = 'vite'` in a project installed from npm, the build and dev server fail immediately:

  ```
  Error [ERR_REQUIRE_ESM]: require() of ES Module .../vite-tsconfig-paths/dist/index.js
  from .../node_modules/@availity/workflow/vite.config.js not supported.
  ```

  ## Root cause

  `vite.config.js` uses `createRequire()` to load 6 packages that are all ESM-only:
  - `vite-tsconfig-paths`
  - `vite-plugin-static-copy`
  - `vite-plugin-checker`
  - `@vitejs/plugin-react-swc` / `@vitejs/plugin-react`
  - `@availity/workflow-logger` (switched from CJS to ESM in v8.0.0)

  This wasn't caught in the monorepo because `workspace:*` resolution handles the CJS/ESM boundary transparently.
  The bug only manifests when consuming the published packages from npm.

  ## Fix

  - Make `buildViteConfig` async, replace all `require()` with `await import()`
  - Make `buildViteProductionConfig` async, `await` the base config
  - Add `await` to callers in `build.js` and `start.js` (both already async)
  - Add regression tests that import and call the real vite configs

  ## Testing

  Added 2 tests to `workflowConfigs.spec.js` that call `buildViteConfig(settings)` and
  `buildViteProductionConfig(settings)` without mocking the plugin imports. Verified tests fail without the fix and
  pass with it.