### PR TITLE
build: pin npm version in deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set Node Version
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -42,9 +42,9 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-22-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-24-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-22-yarn-
+            ${{ runner.os }}-24-yarn-
 
       - name: Install Dependencies
         run: yarn install --immutable
@@ -113,11 +113,11 @@ jobs:
       - name: Set Node Version
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 22
+          node-version: 24
           registry-url: "https://registry.npmjs.org"
 
       - name: Install latest npm
-        run: npm install -g npm@~11.10.0
+        run: npm install -g npm@latest
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -129,9 +129,9 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-22-yarn-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-24-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-22-yarn-
+            ${{ runner.os }}-24-yarn-
 
       - name: Install Dependencies
         run: yarn install --immutable
@@ -199,7 +199,7 @@ jobs:
       - name: Set Node Version
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 22
+          node-version: 24
           cache: "yarn"
           cache-dependency-path: "yarn.lock"
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,11 +5,12 @@ name: Publish Release
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
 
 jobs:
   setup:
-    if: "${{!contains(github.event.head_commit.message, 'skip ci') && !contains(github.event.head_commit.message, 'Release: Version Updates')}}"
+    if: "${{!contains(github.event.head_commit.message, 'skip ci') &&
+      !contains(github.event.head_commit.message, 'Release: Version Updates')}}"
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -19,12 +20,12 @@ jobs:
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
-          ref: 'master'
+          ref: "master"
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
         with:
-          main-branch-name: 'master'
+          main-branch-name: "master"
 
       - name: Set Node Version
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -88,8 +89,9 @@ jobs:
   #     - run: yarn check:versions
 
   publish:
-    if: "${{!contains(github.event.head_commit.message, 'skip ci') && !contains(github.event.head_commit.message, 'Release: Version Updates')}}"
-    needs: [setup]
+    if: "${{!contains(github.event.head_commit.message, 'skip ci') &&
+      !contains(github.event.head_commit.message, 'Release: Version Updates')}}"
+    needs: [ setup ]
     runs-on: ubuntu-latest
     permissions:
       contents: write # Required for git push and creating tags
@@ -101,21 +103,21 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           fetch-depth: 0
-          ref: 'master'
+          ref: "master"
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
         with:
-          main-branch-name: 'master'
+          main-branch-name: "master"
 
       - name: Set Node Version
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install latest npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@~11.10.0
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -178,8 +180,9 @@ jobs:
           gh pr create --title "Release: Version Updates" --body "Automated release PR with version updates and package publications." --base master --head release/version-updates
 
   deploy-docs:
-    if: "${{!contains(github.event.head_commit.message, 'skip ci') && !contains(github.event.head_commit.message, 'Release: Version Updates')}}"
-    needs: [publish]
+    if: "${{!contains(github.event.head_commit.message, 'skip ci') &&
+      !contains(github.event.head_commit.message, 'Release: Version Updates')}}"
+    needs: [ publish ]
     runs-on: ubuntu-latest
     permissions:
       pages: write
@@ -191,14 +194,14 @@ jobs:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
-          ref: 'master'
+          ref: "master"
 
       - name: Set Node Version
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
-          cache: 'yarn'
-          cache-dependency-path: 'yarn.lock'
+          cache: "yarn"
+          cache-dependency-path: "yarn.lock"
 
       - name: Install Dependencies
         run: yarn install --immutable

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -8,15 +8,15 @@ name: Pull Request Build
 
 on:
   pull_request:
-    branches: [master]
+    branches: [ master ]
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        node: [20, 22, 24]
+        os: [ ubuntu-latest, macos-latest ]
+        node: [ 20, 22, 24 ]
 
     steps:
       - name: Checkout Code
@@ -27,7 +27,7 @@ jobs:
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@826660b82addbef3abff5fa871492ebad618c9e1 # v4.3.3
         with:
-          main-branch-name: 'master'
+          main-branch-name: "master"
 
       - name: Set Node Version
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
@@ -67,7 +67,7 @@ jobs:
         run: yarn version:dry-run
 
       - name: Build Docs
-        if: ${{ matrix.node == 22 }}
+        if: ${{ matrix.node == 24 }}
         run: yarn build:docs
 
       - name: Build App


### PR DESCRIPTION
This is to fix an issue with the deploy process. There is a bug when installing the latest version of npm that `promise-retry` can't be found. This pins npm to a version where the bug does not occur