### PR TITLE
fix(workflow-vite): resolve lint hanging in TypeScript-only projects

### DIFF
--- a/packages/workflow-vite/index.js
+++ b/packages/workflow-vite/index.js
@@ -7,7 +7,7 @@ import Settings from './settings/index.js';
 function handleError(command, error) {
   Logger.error(`Command "${command}" failed:`);
   Logger.error(error?.stack || error?.message || error);
-  process.exitCode = 1;
+  process.exit(1);
 }
 
 function getStagingOptions() {

--- a/packages/workflow-vite/scripts/lint.js
+++ b/packages/workflow-vite/scripts/lint.js
@@ -34,7 +34,7 @@ export default async function lint({ settings }) {
 
   let engine;
   try {
-    engine = new eslint.ESLint({});
+    engine = new eslint.ESLint({ errorOnUnmatchedPattern: false });
   } catch (error) {
     Logger.failed(`ESLint configuration error. "${error.message}"`);
     throw new Error(`ESLint configuration error. "${error.message}"`);
@@ -52,7 +52,10 @@ export default async function lint({ settings }) {
       const { stdout: rootOut } = await execFileAsync('git', ['rev-parse', '--show-toplevel']);
       const gitRoot = rootOut.trim();
       const { stdout: filesOut } = await execFileAsync('git', ['ls-files']);
-      const gitTrackedFiles = filesOut.trim().split('\n').map((file) => path.join(gitRoot, file));
+      const gitTrackedFiles = filesOut
+        .trim()
+        .split('\n')
+        .map((file) => path.join(gitRoot, file));
       filesToLint = gitTrackedFiles.filter((file) => ['.js', '.jsx', '.ts', '.tsx'].includes(path.extname(file)));
     } catch {
       // If git commands fail, fall back to default patterns


### PR DESCRIPTION
- Add errorOnUnmatchedPattern: false to ESLint constructor so glob patterns matching zero files (e.g. *.js in TS-only projects) no longer throw
- Change handleError to call process.exit(1) instead of setting process.exitCode so the process terminates on failure instead of hanging on lingering event-loop handles


